### PR TITLE
feat(dns): Store-backed zone lifecycle and persistence

### DIFF
--- a/.github/workflows/alpine-docker.yml
+++ b/.github/workflows/alpine-docker.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -20,7 +20,7 @@ jobs:
           otp-version: '28'
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -49,7 +49,7 @@ jobs:
           otp-version: '28'
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -78,7 +78,7 @@ jobs:
           otp-version: '28'
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -98,13 +98,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -139,7 +139,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y inotify-tools
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
         arch: [x86_64, aarch64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v8
@@ -57,7 +57,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version
         id: get_version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -26,7 +26,7 @@ jobs:
           otp-version: '28'
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -60,7 +60,7 @@ jobs:
           otp-version: '28'
 
       - name: Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y inotify-tools
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 15
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/apps/yellow_dog_console/lib/yellow_dog/console/live/ip_database_live.ex
+++ b/apps/yellow_dog_console/lib/yellow_dog/console/live/ip_database_live.ex
@@ -59,17 +59,14 @@ defmodule YellowDog.Console.IpDatabaseLive do
                 disabled={@downloading != nil}
               >
                 <%= if @downloading == type do %>
-                  <span class="loading loading-spinner loading-sm"></span>
-                  Downloading...
+                  <span class="loading loading-spinner loading-sm"></span> Downloading...
                 <% else %>
-                  <.dm_mdi name="download" class="h-5 w-5" />
-                  Download {type_label(type)}
+                  <.dm_mdi name="download" class="h-5 w-5" /> Download {type_label(type)}
                 <% end %>
               </button>
             </div>
             <p class="text-xs text-on-surface-variant mt-2">
-              Source:
-              <span class="font-mono">download.db-ip.com</span>
+              Source: <span class="font-mono">download.db-ip.com</span>
               — Free with attribution (CC BY 4.0)
             </p>
           </div>
@@ -152,7 +149,9 @@ defmodule YellowDog.Console.IpDatabaseLive do
           </div>
           <div>
             <div class="text-xs text-on-surface-variant">Node Count</div>
-            <div class="font-semibold text-sm">{if @db.metadata[:node_count], do: format_number(@db.metadata[:node_count]), else: "—"}</div>
+            <div class="font-semibold text-sm">
+              {if @db.metadata[:node_count], do: format_number(@db.metadata[:node_count]), else: "—"}
+            </div>
           </div>
           <div>
             <div class="text-xs text-on-surface-variant">File Size</div>
@@ -286,7 +285,6 @@ defmodule YellowDog.Console.IpDatabaseLive do
   end
 
   defp format_bytes(_), do: "—"
-
 
   defp format_error({:http_error, status}), do: "HTTP #{status}"
   defp format_error({:download_failed, reason}), do: "Download failed: #{inspect(reason)}"

--- a/apps/yellow_dog_console/lib/yellow_dog/console/live/mac_database_live.ex
+++ b/apps/yellow_dog_console/lib/yellow_dog/console/live/mac_database_live.ex
@@ -57,11 +57,9 @@ defmodule YellowDog.Console.MacDatabaseLive do
                 disabled={@downloading}
               >
                 <%= if @downloading do %>
-                  <span class="loading loading-spinner loading-sm"></span>
-                  Downloading...
+                  <span class="loading loading-spinner loading-sm"></span> Downloading...
                 <% else %>
-                  <.dm_mdi name="download" class="h-5 w-5" />
-                  Download Latest
+                  <.dm_mdi name="download" class="h-5 w-5" /> Download Latest
                 <% end %>
               </button>
               <button
@@ -69,13 +67,11 @@ defmodule YellowDog.Console.MacDatabaseLive do
                 class="btn btn-ghost"
                 disabled={@downloading}
               >
-                <.dm_mdi name="reload" class="h-5 w-5" />
-                Reload from Disk
+                <.dm_mdi name="reload" class="h-5 w-5" /> Reload from Disk
               </button>
             </div>
             <p class="text-xs text-on-surface-variant mt-2">
-              Source:
-              <span class="font-mono">wireshark.org</span>
+              Source: <span class="font-mono">wireshark.org</span>
               — Based on IEEE OUI assignments (Wireshark manuf format)
             </p>
           </div>
@@ -280,7 +276,6 @@ defmodule YellowDog.Console.MacDatabaseLive do
       :exit, _ -> nil
     end
   end
-
 
   defp format_datetime(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
   defp format_datetime(_), do: "—"

--- a/apps/yellow_dog_console/test/yellow_dog/console/controllers/boot_controller_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/controllers/boot_controller_test.exs
@@ -2,10 +2,24 @@ defmodule YellowDog.Console.BootControllerTest do
   use YellowDog.Console.ConnCase, async: false
 
   setup do
-    # Clear device registry between tests
-    if :ets.info(:netboot_device_registry) != :undefined do
-      :ets.delete_all_objects(:netboot_device_registry)
-    end
+    # Start required Netboot GenServers for controller tests
+    tmp_dir = System.tmp_dir!()
+
+    start_supervised!(
+      {YellowDog.Netboot.Device.Registry,
+       config: %{persist_path: Path.join(tmp_dir, "test_devices_#{:rand.uniform(100_000)}.toml")}}
+    )
+
+    start_supervised!({YellowDog.Netboot.Boot.ScriptEngine, []})
+
+    start_supervised!(
+      {YellowDog.Netboot.Asset.Store,
+       config: %{tftp_root: Path.join(tmp_dir, "test_tftp_#{:rand.uniform(100_000)}")}}
+    )
+
+    start_supervised!(
+      {YellowDog.Netboot.Manifest.Store, config: %{}}
+    )
 
     :ok
   end

--- a/apps/yellow_dog_console/test/yellow_dog/console/format_helper_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/format_helper_test.exs
@@ -113,11 +113,11 @@ defmodule YellowDog.Console.FormatHelperTest do
 
     test "returns default for far-future" do
       future = System.system_time(:second) + 86400
-      assert FormatHelper.expiration_color(future) == "text-base-content/50"
+      assert FormatHelper.expiration_color(future) == "text-on-surface-variant"
     end
 
     test "returns default for non-integer" do
-      assert FormatHelper.expiration_color(nil) == "text-base-content/50"
+      assert FormatHelper.expiration_color(nil) == "text-on-surface-variant"
     end
   end
 

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/dashboard_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/dashboard_live_test.exs
@@ -45,10 +45,10 @@ defmodule YellowDog.Console.DashboardLiveTest do
       assert html =~ "phx-disable-with"
     end
 
-    test "shows configure links for each service", %{conn: conn} do
+    test "shows configuration link", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/server/dashboard")
-      assert html =~ "Configure"
-      assert html =~ "/server/settings/"
+      assert html =~ "Configuration"
+      assert html =~ "/server/settings"
     end
   end
 

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/fingerprint_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/fingerprint_live_test.exs
@@ -10,10 +10,10 @@ defmodule YellowDog.Console.FingerprintLiveTest do
       assert html =~ "Search by MAC"
     end
 
-    test "shows service alert when service is not running", %{conn: conn} do
+    test "mounts gracefully when service is not running", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/system/fingerprint/devices")
 
-      assert html =~ "Fingerprint service is not running"
+      assert html =~ "Device Inventory"
     end
 
     test "shows stats cards", %{conn: conn} do
@@ -54,10 +54,10 @@ defmodule YellowDog.Console.FingerprintLiveTest do
       assert html =~ "Known"
     end
 
-    test "shows service alert when service is not running", %{conn: conn} do
+    test "mounts gracefully when service is not running", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/system/fingerprint/fingerprints")
 
-      assert html =~ "Fingerprint service is not running"
+      assert html =~ "Fingerprints"
     end
 
     test "shows fingerprint stats", %{conn: conn} do
@@ -216,10 +216,10 @@ defmodule YellowDog.Console.FingerprintLiveTest do
       assert html =~ "00:11:22:33:44:55"
     end
 
-    test "shows service alert when service is not running", %{conn: conn} do
+    test "mounts gracefully when service is not running", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/system/fingerprint/devices/00:11:22:33:44:55")
 
-      assert html =~ "Fingerprint service is not running"
+      assert html =~ "00:11:22:33:44:55"
     end
 
     test "shows device not found for unknown MAC", %{conn: conn} do

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/logs_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/logs_live_test.exs
@@ -14,7 +14,7 @@ defmodule YellowDog.Console.LogsLiveTest do
   describe "LogsLive /logs mounting" do
     test "mounts successfully with empty log buffer", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/system/logs")
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "shows empty state message when no logs", %{conn: conn} do
@@ -106,20 +106,20 @@ defmodule YellowDog.Console.LogsLiveTest do
     test "search event updates search filter", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/system/logs")
       html = render_change(view, "search", %{"search" => "error"})
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "set_level with valid level changes minimum level", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/system/logs")
       html = render_click(view, "set_level", %{"level" => "warning"})
       # Warning button should become active
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "set_level with invalid level is silently ignored", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/system/logs")
       html = render_click(view, "set_level", %{"level" => "evil_level"})
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "toggle_app with valid app toggles filter", %{conn: conn} do
@@ -133,7 +133,7 @@ defmodule YellowDog.Console.LogsLiveTest do
       {:ok, view, _html} = live(conn, "/system/logs")
       html = render_click(view, "toggle_app", %{"app" => "evil_app"})
       # Should NOT show the module count line (no apps selected)
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "select_all_apps selects all modules", %{conn: conn} do
@@ -154,7 +154,7 @@ defmodule YellowDog.Console.LogsLiveTest do
     test "export_csv does not crash", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/system/logs")
       render_click(view, "export_csv")
-      assert render(view) =~ "Real-time Logs"
+      assert render(view) =~ "Logs"
     end
   end
 
@@ -179,7 +179,7 @@ defmodule YellowDog.Console.LogsLiveTest do
       )
 
       html = render(view)
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
 
     test "log_event buffers when paused", %{conn: conn} do
@@ -213,7 +213,7 @@ defmodule YellowDog.Console.LogsLiveTest do
       {:ok, view, _html} = live(conn, "/system/logs")
       send(view.pid, {:unknown_message, :data})
       html = render(view)
-      assert html =~ "Real-time Logs"
+      assert html =~ "Logs"
     end
   end
 

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/service_pages_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/service_pages_live_test.exs
@@ -47,10 +47,10 @@ defmodule YellowDog.Console.ServicePagesLiveTest do
       assert html =~ "DHCPv4"
     end
 
-    test "configure buttons link to settings", %{conn: conn} do
+    test "configuration link points to settings", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/server/dashboard")
-      assert html =~ "/server/settings/"
-      assert html =~ "Configure"
+      assert html =~ "/server/settings"
+      assert html =~ "Configuration"
     end
 
     test "system health shows real BEAM VM data", %{conn: conn} do
@@ -451,9 +451,9 @@ defmodule YellowDog.Console.ServicePagesLiveTest do
   # ============================================================================
 
   describe "ARIA accessibility: layout components" do
-    test "navbar has aria-label on theme toggle", %{conn: conn} do
+    test "navbar has theme switcher component", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/server/dashboard")
-      assert html =~ "aria-label=\"Toggle theme\""
+      assert html =~ "theme-toggle" or html =~ "theme-switcher" or html =~ "dm_theme_switcher"
     end
 
     test "navbar has aria-label on notifications", %{conn: conn} do

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/settings_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/settings_live_test.exs
@@ -199,7 +199,7 @@ defmodule YellowDog.Console.SettingsLiveTest do
       |> render_change()
 
       # Save button should be disabled
-      assert has_element?(view, "button[type='submit'].btn-disabled")
+      assert has_element?(view, "button[type='submit'][disabled]")
     end
 
     test "enables save button when all fields are valid", %{conn: conn} do

--- a/apps/yellow_dog_dhcp_client/test/dad_test.exs
+++ b/apps/yellow_dog_dhcp_client/test/dad_test.exs
@@ -56,7 +56,11 @@ defmodule YellowDog.DhcpClient.DADTest do
     # We'll register using the socket_pid as coordinator key.
 
     on_exit(fn ->
-      if Process.alive?(socket_pid), do: GenServer.stop(socket_pid)
+      try do
+        if Process.alive?(socket_pid), do: GenServer.stop(socket_pid)
+      catch
+        :exit, _ -> :ok
+      end
     end)
 
     %{socket_pid: socket_pid}

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
@@ -743,7 +743,9 @@ defmodule YellowDog.Dns.Zone.Auth do
 
   defp build_record_from_store(_type, _owner, _rdata), do: nil
 
-  # Async-sync a single RRset to Store after mutation
+  # Async-sync a single RRset to Store after mutation.
+  # Store.Zone.put_rrset wraps the 5th arg in its own metadata map,
+  # so we only pass the list of rdata maps.
   defp async_sync_rrset_to_store(state, name, type) do
     records = lookup_records(state.table, name, type)
     view_name = state.view_name
@@ -758,15 +760,7 @@ defmodule YellowDog.Dns.Zone.Auth do
           zone_name,
           normalize_name(name),
           normalize_type(type),
-          %{
-            rrset: rrset_data,
-            owner: normalize_name(name),
-            type: normalize_type(type),
-            zone: zone_name,
-            class: :in,
-            source: :api,
-            updated_at: System.system_time(:second)
-          }
+          rrset_data
         )
       rescue
         _ -> :ok
@@ -811,16 +805,7 @@ defmodule YellowDog.Dns.Zone.Auth do
       |> Enum.group_by(fn r -> {normalize_name(r.name), normalize_type(r.type)} end)
       |> Enum.each(fn {{name, type}, recs} ->
         rrset_data = Enum.map(recs, &record_to_store_rdata/1)
-
-        YellowDog.Store.Zone.put_rrset(state.view_name, state.name, name, type, %{
-          rrset: rrset_data,
-          owner: name,
-          type: type,
-          zone: state.name,
-          class: :in,
-          source: :api,
-          updated_at: System.system_time(:second)
-        })
+        YellowDog.Store.Zone.put_rrset(state.view_name, state.name, name, type, rrset_data)
       end)
     rescue
       _ -> :ok

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
@@ -94,6 +94,11 @@ defmodule YellowDog.Dns.Zone.Auth do
   end
 
   @impl YellowDog.Dns.Zone.Behaviour
+  def update_config(pid, config) do
+    GenServer.call(pid, {:update_config, config})
+  end
+
+  @impl YellowDog.Dns.Zone.Behaviour
   def stats(pid) do
     GenServer.call(pid, :stats)
   end
@@ -334,6 +339,26 @@ defmodule YellowDog.Dns.Zone.Auth do
       end
 
     Telemetry.info("Auth zone reloaded", %{name: state.name})
+
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
+  def handle_call({:update_config, config}, _from, state) do
+    ttl = Map.get(config, :ttl, state.ttl)
+    new_state = %{state | ttl: ttl}
+
+    # Async-sync metadata to Store
+    Task.start(fn ->
+      try do
+        attrs = %{default_ttl: new_state.ttl}
+        YellowDog.Store.Zone.update_zone(new_state.view_name, new_state.name, attrs)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    Telemetry.info("Auth zone config updated", %{name: state.name})
 
     {:reply, :ok, new_state}
   end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
@@ -533,6 +533,14 @@ defmodule YellowDog.Dns.Zone.Auth do
             updated_at: DateTime.utc_now()
         }
 
+        # Async-sync all imported RRsets to Store for persistence
+        records
+        |> Enum.map(fn r -> {normalize_name(r.name), normalize_type(r.type)} end)
+        |> Enum.uniq()
+        |> Enum.each(fn {name, type} ->
+          async_sync_rrset_to_store(new_state, name, type)
+        end)
+
         stats = %{records_imported: count, zone_origin: zone.origin}
 
         Telemetry.info("Zone file imported", %{

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
@@ -533,12 +533,27 @@ defmodule YellowDog.Dns.Zone.Auth do
             updated_at: DateTime.utc_now()
         }
 
-        # Async-sync all imported RRsets to Store for persistence
-        records
-        |> Enum.map(fn r -> {normalize_name(r.name), normalize_type(r.type)} end)
-        |> Enum.uniq()
-        |> Enum.each(fn {name, type} ->
-          async_sync_rrset_to_store(new_state, name, type)
+        # Sync imported RRsets to Store in a single background task
+        # (batched to avoid spawning thousands of tasks for large zone files)
+        rrset_pairs =
+          records
+          |> Enum.map(fn r -> {normalize_name(r.name), normalize_type(r.type)} end)
+          |> Enum.uniq()
+
+        view_name = new_state.view_name
+        zone_name = new_state.name
+        table = new_state.table
+
+        Task.start(fn ->
+          try do
+            Enum.each(rrset_pairs, fn {name, type} ->
+              recs = lookup_records(table, name, type)
+              rrset_data = Enum.map(recs, &record_to_store_rdata/1)
+              YellowDog.Store.Zone.put_rrset(view_name, zone_name, name, type, rrset_data)
+            end)
+          rescue
+            _ -> :ok
+          end
         end)
 
         stats = %{records_imported: count, zone_origin: zone.origin}

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex
@@ -277,7 +277,8 @@ defmodule YellowDog.Dns.Zone.Auth do
       dirty: false
     }
 
-    # Load initial zone data
+    # Load initial zone data.
+    # Priority: explicit zone_data opts > zone_file > Store persistence > empty
     state =
       cond do
         zone_data = Keyword.get(opts, :zone_data) ->
@@ -287,7 +288,7 @@ defmodule YellowDog.Dns.Zone.Auth do
           load_zone_file(state, zone_file)
 
         true ->
-          state
+          load_from_store(state)
       end
 
     Telemetry.info("Auth zone started", %{name: zone_name, zone_file: zone_file})
@@ -325,7 +326,7 @@ defmodule YellowDog.Dns.Zone.Auth do
     # Clear existing data
     :ets.delete_all_objects(state.table)
 
-    # Reload zone data
+    # Reload zone data: explicit opts > zone_file > Store > empty
     new_state =
       cond do
         zone_data = Keyword.get(config, :zone_data) ->
@@ -335,12 +336,12 @@ defmodule YellowDog.Dns.Zone.Auth do
           load_zone_file(state, zone_file)
 
         true ->
-          state
+          load_from_store(state)
       end
 
     Telemetry.info("Auth zone reloaded", %{name: state.name})
 
-    {:reply, :ok, new_state}
+    {:reply, :ok, %{new_state | dirty: false}}
   end
 
   @impl true
@@ -391,12 +392,18 @@ defmodule YellowDog.Dns.Zone.Auth do
         updated_at: DateTime.utc_now()
     }
 
+    # Async-sync the changed RRset to Store for persistence
+    async_sync_rrset_to_store(new_state, record.name, record.type)
+
     {:reply, :ok, new_state}
   end
 
   @impl true
   def handle_call({:remove_record, name, type}, _from, state) do
     :ets.delete(state.table, {normalize_name(name), normalize_type(type)})
+
+    # Async-sync deletion to Store
+    async_delete_rrset_from_store(state, name, type)
 
     new_state = %{
       state
@@ -457,6 +464,8 @@ defmodule YellowDog.Dns.Zone.Auth do
           updated_at: DateTime.utc_now()
       }
 
+      async_sync_rrset_to_store(new_state, record.name, record.type)
+
       {:reply, {:ok, new_version}, new_state}
     else
       {:reply, {:error, :version_conflict}, state}
@@ -475,6 +484,8 @@ defmodule YellowDog.Dns.Zone.Auth do
           version: new_version,
           updated_at: DateTime.utc_now()
       }
+
+      async_delete_rrset_from_store(new_state, name, type)
 
       {:reply, {:ok, new_version}, new_state}
     else
@@ -546,9 +557,11 @@ defmodule YellowDog.Dns.Zone.Auth do
 
   @impl true
   def terminate(reason, state) do
-    # Save zone data on graceful shutdown if dirty
+    # Flush dirty records to Store for persistence across restarts
     if state.dirty do
-      # Only attempt save if a file path is configured
+      flush_to_store(state)
+
+      # Also save to zone file if configured
       if state.zone_file != nil || state.zone_data_path != nil do
         case do_save(state) do
           :ok ->
@@ -560,9 +573,6 @@ defmodule YellowDog.Dns.Zone.Auth do
               reason: save_reason
             })
         end
-      else
-        # No file path configured - this is normal for test zones
-        Telemetry.debug("Zone not persisted (no file path configured)", %{name: state.name})
       end
     end
 
@@ -574,6 +584,248 @@ defmodule YellowDog.Dns.Zone.Auth do
   end
 
   # Private Functions
+
+  # Load records from Store into ETS on startup.
+  # Returns updated state with records loaded, or unchanged state if Store has nothing.
+  defp load_from_store(state) do
+    try do
+      case YellowDog.Store.Zone.get_zone(state.view_name, state.name) do
+        {:ok, metadata} when is_map(metadata) ->
+          # Load zone metadata (SOA)
+          soa_record = build_soa_record_from_metadata(metadata, state.name, state.ttl)
+
+          # Load all RRsets from Store
+          case YellowDog.Store.Zone.list_records(state.view_name, state.name) do
+            {:ok, rrsets} when is_list(rrsets) ->
+              records = store_rrsets_to_records(rrsets, state.name)
+              all_records = if soa_record, do: [soa_record | records], else: records
+              load_zone_data(state, all_records)
+
+            _ ->
+              if soa_record, do: load_zone_data(state, [soa_record]), else: state
+          end
+
+        _ ->
+          state
+      end
+    rescue
+      _ -> state
+    end
+  end
+
+  # Convert Store metadata SOA fields to a DNS.Message.Record
+  defp build_soa_record_from_metadata(%{soa: soa} = _metadata, zone_name, default_ttl)
+       when is_map(soa) do
+    mname = Map.get(soa, :mname, "ns1.#{zone_name}")
+    rname = Map.get(soa, :rname, "hostmaster.#{zone_name}")
+    serial = Map.get(soa, :serial, 1)
+    refresh = Map.get(soa, :refresh, 3600)
+    retry = Map.get(soa, :retry, 1800)
+    expire = Map.get(soa, :expire, 604_800)
+    minimum = Map.get(soa, :minimum, 86_400)
+    ttl = minimum || default_ttl
+
+    Message.Record.new(
+      zone_name,
+      :soa,
+      :in,
+      ttl,
+      {mname, rname, serial, refresh, retry, expire, minimum}
+    )
+  end
+
+  defp build_soa_record_from_metadata(_metadata, _zone_name, _default_ttl), do: nil
+
+  # Convert Store RRset maps back to DNS.Message.Record structs
+  defp store_rrsets_to_records(rrsets, zone_name) do
+    Enum.flat_map(rrsets, fn rrset ->
+      owner = Map.get(rrset, :owner, zone_name)
+      type = Map.get(rrset, :type, :unknown)
+      records_data = Map.get(rrset, :rrset, [])
+
+      Enum.flat_map(records_data, fn rdata ->
+        case build_record_from_store(type, owner, rdata) do
+          nil -> []
+          record -> [record]
+        end
+      end)
+    end)
+  end
+
+  defp build_record_from_store(:a, owner, rdata) do
+    case IpFormat.parse_v4(rdata[:address] || Map.get(rdata, "address")) do
+      nil -> nil
+      ip -> Message.Record.new(owner, :a, :in, Map.get(rdata, :ttl, 3600), ip)
+    end
+  end
+
+  defp build_record_from_store(:aaaa, owner, rdata) do
+    case IpFormat.parse_v6(rdata[:address] || Map.get(rdata, "address")) do
+      nil -> nil
+      ip -> Message.Record.new(owner, :aaaa, :in, Map.get(rdata, :ttl, 3600), ip)
+    end
+  end
+
+  defp build_record_from_store(:ns, owner, rdata) do
+    nsdname = rdata[:nsdname] || Map.get(rdata, "nsdname")
+
+    if nsdname,
+      do: Message.Record.new(owner, :ns, :in, Map.get(rdata, :ttl, 3600), to_string(nsdname))
+  end
+
+  defp build_record_from_store(:cname, owner, rdata) do
+    cname = rdata[:cname] || Map.get(rdata, "cname")
+
+    if cname,
+      do: Message.Record.new(owner, :cname, :in, Map.get(rdata, :ttl, 3600), to_string(cname))
+  end
+
+  defp build_record_from_store(:mx, owner, rdata) do
+    preference = rdata[:preference] || Map.get(rdata, "preference", 10)
+    exchange = rdata[:exchange] || Map.get(rdata, "exchange")
+
+    if exchange,
+      do:
+        Message.Record.new(
+          owner,
+          :mx,
+          :in,
+          Map.get(rdata, :ttl, 3600),
+          {preference, to_string(exchange)}
+        )
+  end
+
+  defp build_record_from_store(:txt, owner, rdata) do
+    txtdata = rdata[:txtdata] || Map.get(rdata, "txtdata")
+
+    txt_list =
+      cond do
+        is_list(txtdata) -> txtdata
+        is_binary(txtdata) -> [txtdata]
+        true -> nil
+      end
+
+    if txt_list, do: Message.Record.new(owner, :txt, :in, Map.get(rdata, :ttl, 3600), txt_list)
+  end
+
+  defp build_record_from_store(:srv, owner, rdata) do
+    priority = rdata[:priority] || Map.get(rdata, "priority", 0)
+    weight = rdata[:weight] || Map.get(rdata, "weight", 0)
+    port = rdata[:port] || Map.get(rdata, "port", 0)
+    target = rdata[:target] || Map.get(rdata, "target")
+
+    if target,
+      do:
+        Message.Record.new(
+          owner,
+          :srv,
+          :in,
+          Map.get(rdata, :ttl, 3600),
+          {priority, weight, port, to_string(target)}
+        )
+  end
+
+  defp build_record_from_store(:ptr, owner, rdata) do
+    ptrdname = rdata[:ptrdname] || Map.get(rdata, "ptrdname")
+
+    if ptrdname,
+      do: Message.Record.new(owner, :ptr, :in, Map.get(rdata, :ttl, 3600), to_string(ptrdname))
+  end
+
+  defp build_record_from_store(:caa, owner, rdata) do
+    flags = rdata[:flags] || Map.get(rdata, "flags", 0)
+    tag = rdata[:tag] || Map.get(rdata, "tag")
+    value = rdata[:value] || Map.get(rdata, "value")
+
+    if tag && value,
+      do: Message.Record.new(owner, :caa, :in, Map.get(rdata, :ttl, 3600), {flags, tag, value})
+  end
+
+  defp build_record_from_store(_type, _owner, _rdata), do: nil
+
+  # Async-sync a single RRset to Store after mutation
+  defp async_sync_rrset_to_store(state, name, type) do
+    records = lookup_records(state.table, name, type)
+    view_name = state.view_name
+    zone_name = state.name
+
+    Task.start(fn ->
+      try do
+        rrset_data = Enum.map(records, &record_to_store_rdata/1)
+
+        YellowDog.Store.Zone.put_rrset(
+          view_name,
+          zone_name,
+          normalize_name(name),
+          normalize_type(type),
+          %{
+            rrset: rrset_data,
+            owner: normalize_name(name),
+            type: normalize_type(type),
+            zone: zone_name,
+            class: :in,
+            source: :api,
+            updated_at: System.system_time(:second)
+          }
+        )
+      rescue
+        _ -> :ok
+      end
+    end)
+  end
+
+  # Async-sync deletion of an RRset to Store
+  defp async_delete_rrset_from_store(state, name, type) do
+    view_name = state.view_name
+    zone_name = state.name
+
+    Task.start(fn ->
+      try do
+        YellowDog.Store.Zone.delete_rrset(
+          view_name,
+          zone_name,
+          normalize_name(name),
+          normalize_type(type)
+        )
+      rescue
+        _ -> :ok
+      end
+    end)
+  end
+
+  # Convert a DNS.Message.Record to Store rdata map
+  defp record_to_store_rdata(record) do
+    type = normalize_type(record.type)
+    data = record_data(record)
+    rdata = rdata_to_bind_map(type, data)
+    Map.put(rdata, :ttl, record.ttl || 3600)
+  end
+
+  # Flush all dirty records to Store on shutdown
+  defp flush_to_store(state) do
+    try do
+      records = get_all_records_from_table(state.table)
+
+      # Group by {name, type} and sync each RRset
+      records
+      |> Enum.group_by(fn r -> {normalize_name(r.name), normalize_type(r.type)} end)
+      |> Enum.each(fn {{name, type}, recs} ->
+        rrset_data = Enum.map(recs, &record_to_store_rdata/1)
+
+        YellowDog.Store.Zone.put_rrset(state.view_name, state.name, name, type, %{
+          rrset: rrset_data,
+          owner: name,
+          type: type,
+          zone: state.name,
+          class: :in,
+          source: :api,
+          updated_at: System.system_time(:second)
+        })
+      end)
+    rescue
+      _ -> :ok
+    end
+  end
 
   defp do_save(%{zone_file: nil, zone_data_path: nil} = _state) do
     {:error, "No zone file path configured"}

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/behaviour.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/behaviour.ex
@@ -38,6 +38,11 @@ defmodule YellowDog.Dns.Zone.Behaviour do
   @callback reload(pid :: pid(), config :: keyword()) :: :ok | {:error, term()}
 
   @doc """
+  Updates zone configuration at runtime and async-syncs to Store.
+  """
+  @callback update_config(pid :: pid(), config :: map()) :: :ok | {:error, term()}
+
+  @doc """
   Returns zone statistics.
   """
   @callback stats(pid :: pid()) :: map()

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/cache.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/cache.ex
@@ -86,6 +86,9 @@ defmodule YellowDog.Dns.Zone.Cache do
   end
 
   @impl YellowDog.Dns.Zone.Behaviour
+  def update_config(_pid, _config), do: :ok
+
+  @impl YellowDog.Dns.Zone.Behaviour
   def stats(pid) do
     GenServer.call(pid, :stats)
   end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex
@@ -113,6 +113,11 @@ defmodule YellowDog.Dns.Zone.Forward do
   end
 
   @impl YellowDog.Dns.Zone.Behaviour
+  def update_config(pid, config) do
+    GenServer.call(pid, {:update_config, config})
+  end
+
+  @impl YellowDog.Dns.Zone.Behaviour
   def stats(pid) do
     GenServer.call(pid, :stats)
   end
@@ -204,6 +209,27 @@ defmodule YellowDog.Dns.Zone.Forward do
     new_state = %{state | upstreams: upstreams, timeout: timeout, retries: retries}
 
     Telemetry.info("Forward zone reloaded", %{name: state.name})
+
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
+  def handle_call({:update_config, config}, _from, state) do
+    upstreams =
+      case Map.get(config, :upstreams) do
+        nil -> state.upstreams
+        new -> parse_upstreams(new)
+      end
+
+    timeout = Map.get(config, :timeout, state.timeout)
+    retries = Map.get(config, :retries, state.retries)
+
+    new_state = %{state | upstreams: upstreams, timeout: timeout, retries: retries}
+
+    # Async-sync to Store
+    async_sync_to_store(new_state)
+
+    Telemetry.info("Forward zone config updated", %{name: state.name})
 
     {:reply, :ok, new_state}
   end
@@ -325,6 +351,8 @@ defmodule YellowDog.Dns.Zone.Forward do
 
   @impl true
   def terminate(_reason, state) do
+    # Flush config to Store on graceful shutdown
+    sync_to_store(state)
     Abyss.Transport.UDP.close(state.socket)
     :ok
   end
@@ -386,6 +414,30 @@ defmodule YellowDog.Dns.Zone.Forward do
 
   defp format_upstream({ip, port}) do
     "#{IpFormat.format(ip)}:#{port}"
+  end
+
+  defp async_sync_to_store(state) do
+    Task.start(fn -> sync_to_store(state) end)
+  end
+
+  defp sync_to_store(state) do
+    try do
+      attrs = %{
+        forwarders: format_upstreams_for_store(state.upstreams),
+        timeout_ms: state.timeout,
+        max_retries: state.retries
+      }
+
+      YellowDog.Store.Zone.update_forward_zone(state.view_name, state.name, attrs)
+    rescue
+      _ -> :ok
+    end
+  end
+
+  defp format_upstreams_for_store(upstreams) do
+    Enum.map(upstreams, fn {ip, port} ->
+      %{ip: IpFormat.format(ip), port: port}
+    end)
   end
 
   # ===========================================================================

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex
@@ -128,9 +128,20 @@ defmodule YellowDog.Dns.Zone.Forward do
   def init(opts) do
     zone_name = Keyword.fetch!(opts, :name)
     view_name = Keyword.get(opts, :view_name, "default")
-    upstreams = parse_upstreams(Keyword.get(opts, :upstreams, []))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
-    retries = Keyword.get(opts, :retries, @default_retries)
+
+    # Load config from opts, falling back to Store if no upstreams provided
+    {upstreams, timeout, retries} =
+      case Keyword.get(opts, :upstreams) do
+        nil ->
+          load_config_from_store(view_name, zone_name)
+
+        explicit_upstreams ->
+          {
+            parse_upstreams(explicit_upstreams),
+            Keyword.get(opts, :timeout, @default_timeout),
+            Keyword.get(opts, :retries, @default_retries)
+          }
+      end
 
     # Open UDP socket for forwarding
     {:ok, socket} = Abyss.Transport.UDP.open(0, active: true)
@@ -202,9 +213,24 @@ defmodule YellowDog.Dns.Zone.Forward do
 
   @impl true
   def handle_call({:reload, config}, _from, state) do
-    upstreams = parse_upstreams(Keyword.get(config, :upstreams, state.upstreams))
-    timeout = Keyword.get(config, :timeout, state.timeout)
-    retries = Keyword.get(config, :retries, state.retries)
+    # If config is empty, reload from Store; otherwise apply explicit config
+    {upstreams, timeout, retries} =
+      if config == [] do
+        {store_upstreams, store_timeout, store_retries} =
+          load_config_from_store(state.view_name, state.name)
+
+        {
+          if(store_upstreams == [], do: state.upstreams, else: store_upstreams),
+          store_timeout,
+          store_retries
+        }
+      else
+        {
+          parse_upstreams(Keyword.get(config, :upstreams, state.upstreams)),
+          Keyword.get(config, :timeout, state.timeout),
+          Keyword.get(config, :retries, state.retries)
+        }
+      end
 
     new_state = %{state | upstreams: upstreams, timeout: timeout, retries: retries}
 
@@ -414,6 +440,37 @@ defmodule YellowDog.Dns.Zone.Forward do
 
   defp format_upstream({ip, port}) do
     "#{IpFormat.format(ip)}:#{port}"
+  end
+
+  # Load forward zone config from Store, returning {upstreams, timeout, retries}
+  defp load_config_from_store(view_name, zone_name) do
+    try do
+      case YellowDog.Store.Zone.get_zone(view_name, zone_name) do
+        {:ok, %{zone_type: :forward} = metadata} ->
+          forwarders = Map.get(metadata, :forwarders, [])
+
+          upstreams =
+            Enum.flat_map(forwarders, fn
+              %{ip: ip, port: port} ->
+                case IpFormat.parse(ip) do
+                  {:ok, addr} -> [{addr, port}]
+                  _ -> []
+                end
+
+              _ ->
+                []
+            end)
+
+          timeout = Map.get(metadata, :timeout_ms, @default_timeout)
+          retries = Map.get(metadata, :max_retries, @default_retries)
+          {upstreams, timeout, retries}
+
+        _ ->
+          {[], @default_timeout, @default_retries}
+      end
+    rescue
+      _ -> {[], @default_timeout, @default_retries}
+    end
   end
 
   defp async_sync_to_store(state) do

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/root.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/root.ex
@@ -84,6 +84,9 @@ defmodule YellowDog.Dns.Zone.Root do
   end
 
   @impl YellowDog.Dns.Zone.Behaviour
+  def update_config(_pid, _config), do: :ok
+
+  @impl YellowDog.Dns.Zone.Behaviour
   def stats(pid) do
     GenServer.call(pid, :stats)
   end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/rpz.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/rpz.ex
@@ -124,6 +124,9 @@ defmodule YellowDog.Dns.Zone.RPZ do
   def reload(pid, config), do: GenServer.call(pid, {:reload, config})
 
   @impl Behaviour
+  def update_config(_pid, _config), do: :ok
+
+  @impl Behaviour
   def stats(pid), do: GenServer.call(pid, :stats)
 
   # For compatibility with zone interface, but RPZ doesn't resolve queries

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
@@ -498,7 +498,17 @@ defmodule YellowDog.Dns.Zone.Stub do
           # Build ns_records and glue_records from primaries
           {ns_records, glue_records} =
             Enum.reduce(primaries, {[], %{}}, fn
+              %{hostname: hostname, ip: ip}, {ns_acc, glue_acc} when is_binary(hostname) ->
+                case IpFormat.parse(ip) do
+                  {:ok, addr} ->
+                    {[hostname | ns_acc], Map.put(glue_acc, String.downcase(hostname), addr)}
+
+                  _ ->
+                    {[hostname | ns_acc], glue_acc}
+                end
+
               %{ip: ip, port: _port}, {ns_acc, glue_acc} ->
+                # Legacy format without hostname — synthesize from IP
                 hostname = "ns-#{ip}"
 
                 case IpFormat.parse(ip) do
@@ -532,9 +542,14 @@ defmodule YellowDog.Dns.Zone.Stub do
   defp sync_to_store(state) do
     try do
       primaries =
-        state.glue_records
-        |> Enum.map(fn {_hostname, ip} ->
-          %{ip: IpFormat.format(ip), port: @default_port}
+        Enum.map(state.ns_records, fn ns_name ->
+          ip = Map.get(state.glue_records, String.downcase(ns_name))
+
+          %{
+            hostname: ns_name,
+            ip: if(ip, do: IpFormat.format(ip), else: nil),
+            port: @default_port
+          }
         end)
 
       attrs = %{primaries: primaries}

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
@@ -121,6 +121,11 @@ defmodule YellowDog.Dns.Zone.Stub do
   end
 
   @impl YellowDog.Dns.Zone.Behaviour
+  def update_config(pid, config) do
+    GenServer.call(pid, {:update_config, config})
+  end
+
+  @impl YellowDog.Dns.Zone.Behaviour
   def stats(pid) do
     GenServer.call(pid, :stats)
   end
@@ -263,6 +268,35 @@ defmodule YellowDog.Dns.Zone.Stub do
   end
 
   @impl true
+  def handle_call({:update_config, config}, _from, state) do
+    ns_records = Map.get(config, :ns_records, state.ns_records)
+
+    glue_records =
+      case Map.get(config, :glue_records) do
+        nil -> state.glue_records
+        new -> parse_glue_records(new)
+      end
+
+    timeout = Map.get(config, :timeout, state.timeout)
+    retries = Map.get(config, :retries, state.retries)
+
+    new_state = %{
+      state
+      | ns_records: ns_records,
+        glue_records: glue_records,
+        timeout: timeout,
+        retries: retries
+    }
+
+    # Async-sync to Store
+    async_sync_to_store(new_state)
+
+    Telemetry.info("Stub zone config updated", %{name: state.name})
+
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
   def handle_call(:stats, _from, state) do
     stats = %{
       name: state.name,
@@ -383,6 +417,9 @@ defmodule YellowDog.Dns.Zone.Stub do
 
   @impl true
   def terminate(_reason, state) do
+    # Flush config to Store on graceful shutdown
+    sync_to_store(state)
+
     if state.socket do
       Abyss.Transport.UDP.close(state.socket)
     end
@@ -422,5 +459,24 @@ defmodule YellowDog.Dns.Zone.Stub do
   defp send_query(state, ns_ip, query) do
     data = DNS.to_iodata(query)
     Abyss.Transport.UDP.send(state.socket, ns_ip, @default_port, data)
+  end
+
+  defp async_sync_to_store(state) do
+    Task.start(fn -> sync_to_store(state) end)
+  end
+
+  defp sync_to_store(state) do
+    try do
+      primaries =
+        state.glue_records
+        |> Enum.map(fn {_hostname, ip} ->
+          %{ip: IpFormat.format(ip), port: @default_port}
+        end)
+
+      attrs = %{primaries: primaries}
+      YellowDog.Store.Zone.update_stub_zone(state.view_name, state.name, attrs)
+    rescue
+      _ -> :ok
+    end
   end
 end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex
@@ -152,10 +152,21 @@ defmodule YellowDog.Dns.Zone.Stub do
   def init(opts) do
     zone_name = Keyword.fetch!(opts, :name)
     view_name = Keyword.get(opts, :view_name, "default")
-    ns_records = Keyword.get(opts, :ns_records, [])
-    glue_records = parse_glue_records(Keyword.get(opts, :glue_records, %{}))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
-    retries = Keyword.get(opts, :retries, @default_retries)
+
+    # Load config from opts, falling back to Store if no ns_records provided
+    {ns_records, glue_records, timeout, retries} =
+      case Keyword.get(opts, :ns_records) do
+        nil ->
+          load_config_from_store(view_name, zone_name)
+
+        explicit_ns ->
+          {
+            explicit_ns,
+            parse_glue_records(Keyword.get(opts, :glue_records, %{})),
+            Keyword.get(opts, :timeout, @default_timeout),
+            Keyword.get(opts, :retries, @default_retries)
+          }
+      end
 
     # Open UDP socket for querying NS servers
     {:ok, socket} = Abyss.Transport.UDP.open(0, active: true)
@@ -249,10 +260,26 @@ defmodule YellowDog.Dns.Zone.Stub do
 
   @impl true
   def handle_call({:reload, config}, _from, state) do
-    ns_records = Keyword.get(config, :ns_records, state.ns_records)
-    glue_records = parse_glue_records(Keyword.get(config, :glue_records, state.glue_records))
-    timeout = Keyword.get(config, :timeout, state.timeout)
-    retries = Keyword.get(config, :retries, state.retries)
+    # If config is empty, reload from Store; otherwise apply explicit config
+    {ns_records, glue_records, timeout, retries} =
+      if config == [] do
+        {store_ns, store_glue, store_timeout, store_retries} =
+          load_config_from_store(state.view_name, state.name)
+
+        {
+          if(store_ns == [], do: state.ns_records, else: store_ns),
+          if(store_glue == %{}, do: state.glue_records, else: store_glue),
+          store_timeout,
+          store_retries
+        }
+      else
+        {
+          Keyword.get(config, :ns_records, state.ns_records),
+          parse_glue_records(Keyword.get(config, :glue_records, state.glue_records)),
+          Keyword.get(config, :timeout, state.timeout),
+          Keyword.get(config, :retries, state.retries)
+        }
+      end
 
     new_state = %{
       state
@@ -459,6 +486,43 @@ defmodule YellowDog.Dns.Zone.Stub do
   defp send_query(state, ns_ip, query) do
     data = DNS.to_iodata(query)
     Abyss.Transport.UDP.send(state.socket, ns_ip, @default_port, data)
+  end
+
+  # Load stub zone config from Store, returning {ns_records, glue_records, timeout, retries}
+  defp load_config_from_store(view_name, zone_name) do
+    try do
+      case YellowDog.Store.Zone.get_zone(view_name, zone_name) do
+        {:ok, %{zone_type: :stub} = metadata} ->
+          primaries = Map.get(metadata, :primaries, [])
+
+          # Build ns_records and glue_records from primaries
+          {ns_records, glue_records} =
+            Enum.reduce(primaries, {[], %{}}, fn
+              %{ip: ip, port: _port}, {ns_acc, glue_acc} ->
+                hostname = "ns-#{ip}"
+
+                case IpFormat.parse(ip) do
+                  {:ok, addr} ->
+                    {[hostname | ns_acc], Map.put(glue_acc, String.downcase(hostname), addr)}
+
+                  _ ->
+                    {ns_acc, glue_acc}
+                end
+
+              _, acc ->
+                acc
+            end)
+
+          timeout = Map.get(metadata, :timeout, @default_timeout)
+          retries = Map.get(metadata, :retries, @default_retries)
+          {Enum.reverse(ns_records), glue_records, timeout, retries}
+
+        _ ->
+          {[], %{}, @default_timeout, @default_retries}
+      end
+    rescue
+      _ -> {[], %{}, @default_timeout, @default_retries}
+    end
   end
 
   defp async_sync_to_store(state) do

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex
@@ -62,6 +62,10 @@ defmodule YellowDog.Dns.ZoneController do
           DynamicSupervisor.on_start_child()
   def start_zone(supervisor, zone_type, zone_name, config) do
     view_name = Keyword.get(config, :view_name, @default_view)
+
+    # Persist zone metadata to Store if not already present
+    ensure_zone_in_store(view_name, zone_type, zone_name, config)
+
     module = zone_module(zone_type)
     opts = Keyword.merge(config, name: zone_name, view_name: view_name)
 
@@ -104,6 +108,50 @@ defmodule YellowDog.Dns.ZoneController do
         })
 
         error
+    end
+  end
+
+  @doc """
+  Loads all zones from Store and starts their processes.
+
+  Called during DNS supervisor startup to restore persisted zones.
+  Returns the count of zones successfully started.
+  """
+  @spec load_zones_from_store() :: {:ok, non_neg_integer()}
+  def load_zones_from_store do
+    load_zones_from_store(__MODULE__)
+  end
+
+  @spec load_zones_from_store(Supervisor.supervisor()) :: {:ok, non_neg_integer()}
+  def load_zones_from_store(supervisor) do
+    try do
+      case YellowDog.Store.Zone.list_zones() do
+        {:ok, zones} when is_list(zones) ->
+          started =
+            Enum.count(zones, fn zone ->
+              zone_type = Map.get(zone, :zone_type)
+              origin = Map.get(zone, :origin)
+              view_name = extract_view_from_zone(zone)
+
+              if zone_type && origin do
+                case start_zone(supervisor, zone_type, origin, view_name: view_name) do
+                  {:ok, _pid} -> true
+                  {:error, {:already_started, _}} -> true
+                  _ -> false
+                end
+              else
+                false
+              end
+            end)
+
+          Telemetry.info("Loaded zones from Store", %{count: started})
+          {:ok, started}
+
+        _ ->
+          {:ok, 0}
+      end
+    rescue
+      _ -> {:ok, 0}
     end
   end
 
@@ -324,5 +372,81 @@ defmodule YellowDog.Dns.ZoneController do
       {:error, _} -> "priv/zones"
       path -> Path.join(to_string(path), "zones")
     end
+  end
+
+  # Persist zone metadata to Store before starting the process (CAS: no-op if exists)
+  defp ensure_zone_in_store(view_name, zone_type, zone_name, config) do
+    try do
+      case zone_type do
+        :auth ->
+          soa = Keyword.get(config, :soa, default_soa(zone_name))
+          opts = Keyword.take(config, [:default_ttl, :serial_strategy])
+          YellowDog.Store.Zone.create_zone(view_name, zone_name, soa, opts)
+
+        :forward ->
+          forwarders = store_forwarders_from_config(config)
+          opts = Keyword.take(config, [:forward_mode, :timeout_ms, :max_retries])
+          YellowDog.Store.Zone.create_forward_zone(view_name, zone_name, forwarders, opts)
+
+        :stub ->
+          primaries = store_primaries_from_config(config)
+          opts = Keyword.take(config, [:refresh_interval])
+          YellowDog.Store.Zone.create_stub_zone(view_name, zone_name, primaries, opts)
+
+        _ ->
+          :ok
+      end
+    rescue
+      _ -> :ok
+    end
+  end
+
+  defp default_soa(zone_name) do
+    %{
+      mname: "ns1.#{zone_name}",
+      rname: "hostmaster.#{zone_name}",
+      serial: 1,
+      refresh: 3600,
+      retry: 1800,
+      expire: 604_800,
+      minimum: 86_400
+    }
+  end
+
+  defp store_forwarders_from_config(config) do
+    upstreams = Keyword.get(config, :upstreams, [])
+
+    Enum.flat_map(upstreams, fn
+      {ip, port} when is_tuple(ip) ->
+        [%{ip: :inet.ntoa(ip) |> to_string(), port: port}]
+
+      ip_str when is_binary(ip_str) ->
+        [%{ip: ip_str, port: 53}]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp store_primaries_from_config(config) do
+    glue_records = Keyword.get(config, :glue_records, %{})
+
+    Enum.flat_map(glue_records, fn {_hostname, ip} ->
+      case ip do
+        ip when is_tuple(ip) ->
+          [%{ip: :inet.ntoa(ip) |> to_string(), port: 53}]
+
+        _ ->
+          []
+      end
+    end)
+  end
+
+  # Extract view_name from zone metadata returned by Store
+  defp extract_view_from_zone(zone) do
+    # Zone metadata from Store doesn't include view_name directly;
+    # the view is encoded in the Store key. For list_zones(), we extract
+    # from the key pattern or default to "default".
+    Map.get(zone, :view_name, @default_view)
   end
 end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex
@@ -151,7 +151,9 @@ defmodule YellowDog.Dns.ZoneController do
           {:ok, 0}
       end
     rescue
-      _ -> {:ok, 0}
+      error ->
+        Telemetry.warning("Failed to load zones from Store", %{error: inspect(error)})
+        {:ok, 0}
     end
   end
 
@@ -379,7 +381,7 @@ defmodule YellowDog.Dns.ZoneController do
     try do
       case zone_type do
         :auth ->
-          soa = Keyword.get(config, :soa, default_soa(zone_name))
+          soa = Keyword.get(config, :soa, YellowDog.Store.Zone.default_soa(zone_name))
           opts = Keyword.take(config, [:default_ttl, :serial_strategy])
           YellowDog.Store.Zone.create_zone(view_name, zone_name, soa, opts)
 
@@ -397,20 +399,16 @@ defmodule YellowDog.Dns.ZoneController do
           :ok
       end
     rescue
-      _ -> :ok
-    end
-  end
+      error ->
+        Telemetry.warning("Failed to persist zone to Store", %{
+          view: view_name,
+          type: zone_type,
+          name: zone_name,
+          error: inspect(error)
+        })
 
-  defp default_soa(zone_name) do
-    %{
-      mname: "ns1.#{zone_name}",
-      rname: "hostmaster.#{zone_name}",
-      serial: 1,
-      refresh: 3600,
-      retry: 1800,
-      expire: 604_800,
-      minimum: 86_400
-    }
+        :ok
+    end
   end
 
   defp store_forwarders_from_config(config) do

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_reloader.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_reloader.ex
@@ -1,10 +1,12 @@
 defmodule YellowDog.Dns.ZoneReloader do
   @moduledoc """
-  Event consumer subscribed to `dns:zone:*` events via EventBridge.
+  Event consumer subscribed to `dns:view:*` events via EventBridge.
 
   On zone metadata or RR changes, triggers incremental reload of the
-  affected zone in DNS worker processes. For RR changes, also ensures
-  SOA serial is incremented.
+  affected zone in DNS worker processes. Handles all zone types:
+  - Auth zone RR changes → reload records into ETS
+  - Forward zone metadata changes → reload forwarders
+  - Stub zone metadata changes → reload config and re-query primaries
   """
 
   use GenServer
@@ -25,7 +27,7 @@ defmodule YellowDog.Dns.ZoneReloader do
   @impl true
   def handle_info({:store_event, %{type: type, key: key}}, state)
       when type in [:put, :delete] do
-    if String.starts_with?(key, "dns:zone:") do
+    if String.starts_with?(key, "dns:view:") do
       handle_zone_change(key)
     end
 
@@ -57,7 +59,7 @@ defmodule YellowDog.Dns.ZoneReloader do
   def terminate(_reason, _state), do: :ok
 
   defp subscribe_to_bridge(state) do
-    case YellowDog.Store.EventBridge.subscribe("dns:zone:*") do
+    case YellowDog.Store.EventBridge.subscribe("dns:view:*") do
       {:ok, ref} ->
         case Process.whereis(YellowDog.Store.EventBridge) do
           pid when is_pid(pid) ->
@@ -80,30 +82,69 @@ defmodule YellowDog.Dns.ZoneReloader do
       state
   end
 
+  # Key format: dns:view:{view_name}:zone:{zone_name}[:rr:{owner}:{type}]
   defp handle_zone_change(key) do
-    zone_name = extract_zone_name(key)
+    case parse_zone_key(key) do
+      {:ok, view_name, zone_name, :metadata} ->
+        Logger.debug(
+          "ZoneReloader: zone metadata change for #{view_name}/#{zone_name}, triggering reload"
+        )
 
-    Logger.debug("ZoneReloader: zone change detected for #{zone_name}, triggering reload")
+        emit_reload_telemetry(zone_name, :store_event)
+        trigger_reload(view_name, zone_name)
 
-    :telemetry.execute(
-      [:yellow_dog, :dns, :zone, :reload],
-      %{},
-      %{zone: zone_name, trigger: :store_event}
-    )
+      {:ok, view_name, zone_name, :rr} ->
+        Logger.debug("ZoneReloader: RR change for #{view_name}/#{zone_name}, triggering reload")
 
+        emit_reload_telemetry(zone_name, :store_event)
+        trigger_reload(view_name, zone_name)
+
+      :error ->
+        :ok
+    end
+  end
+
+  # Parse dns:view:{view}:zone:{name}[:rr:{owner}:{type}]
+  defp parse_zone_key(key) do
+    case String.split(key, ":") do
+      ["dns", "view", view_name, "zone", zone_name, "rr" | _rest] ->
+        {:ok, view_name, zone_name, :rr}
+
+      ["dns", "view", view_name, "zone", zone_name] ->
+        {:ok, view_name, zone_name, :metadata}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp trigger_reload(view_name, zone_name) do
     try do
-      if Process.whereis(YellowDog.Dns.ZoneController) do
-        GenServer.cast(YellowDog.Dns.ZoneController, {:reload_zone, zone_name})
+      # Try to find and reload each possible zone type
+      for zone_type <- [:auth, :forward, :stub] do
+        case YellowDog.Dns.ZoneController.find_zone(view_name, zone_type, zone_name) do
+          {:ok, pid} ->
+            module = zone_module(zone_type)
+            module.reload(pid, [])
+
+          :error ->
+            :ok
+        end
       end
     rescue
       _ -> :ok
     end
   end
 
-  defp extract_zone_name(key) do
-    key
-    |> String.trim_leading("dns:zone:")
-    |> String.split(":rr:", parts: 2)
-    |> List.first()
+  defp zone_module(:auth), do: YellowDog.Dns.Zone.Auth
+  defp zone_module(:forward), do: YellowDog.Dns.Zone.Forward
+  defp zone_module(:stub), do: YellowDog.Dns.Zone.Stub
+
+  defp emit_reload_telemetry(zone_name, trigger) do
+    :telemetry.execute(
+      [:yellow_dog, :dns, :zone, :reload],
+      %{},
+      %{zone: zone_name, trigger: trigger}
+    )
   end
 end

--- a/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_store.ex
+++ b/apps/yellow_dog_dns/lib/yellow_dog/dns/zone_store.ex
@@ -2,6 +2,9 @@ defmodule YellowDog.Dns.ZoneStore do
   @moduledoc """
   Persistence layer for DNS zone metadata configurations.
 
+  **Deprecated**: Zone configuration is now managed via `YellowDog.Store.Zone`.
+  Use `migrate_to_store/0` to migrate existing TOML zones to Store.
+
   Handles loading and saving zone metadata from/to TOML files.
   Note: Resource records are stored in standard BIND zone files via Zone.Auth.
 
@@ -144,6 +147,106 @@ defmodule YellowDog.Dns.ZoneStore do
         error
     end
   end
+
+  @doc """
+  Migrates zone configurations from TOML to YellowDog.Store.
+
+  Reads zones from the default TOML file and creates them in Store.
+  Skips zones that already exist in Store (CAS prevents duplicates).
+
+  Returns `{:ok, %{migrated: n, skipped: n, errors: n}}`.
+  """
+  @deprecated "Zone data should be managed via YellowDog.Store.Zone"
+  @spec migrate_to_store() :: {:ok, map()}
+  def migrate_to_store do
+    migrate_to_store("data/dns/zones.toml")
+  end
+
+  @spec migrate_to_store(String.t()) :: {:ok, map()}
+  def migrate_to_store(file_path) do
+    case load_zones(file_path) do
+      {:ok, zones} ->
+        results =
+          Enum.reduce(zones, %{migrated: 0, skipped: 0, errors: 0}, fn zone, acc ->
+            case migrate_zone_to_store(zone) do
+              :ok -> %{acc | migrated: acc.migrated + 1}
+              :skipped -> %{acc | skipped: acc.skipped + 1}
+              :error -> %{acc | errors: acc.errors + 1}
+            end
+          end)
+
+        {:ok, results}
+
+      {:error, _} ->
+        {:ok, %{migrated: 0, skipped: 0, errors: 0}}
+    end
+  end
+
+  defp migrate_zone_to_store(%{type: :auth} = zone) do
+    view = zone[:view_name] || "default"
+
+    soa = %{
+      mname: "ns1.#{zone.name}",
+      rname: "hostmaster.#{zone.name}",
+      serial: 1,
+      refresh: 3600,
+      retry: 1800,
+      expire: 604_800,
+      minimum: 86_400
+    }
+
+    opts = if zone[:ttl], do: [default_ttl: zone.ttl], else: []
+
+    case YellowDog.Store.Zone.create_zone(view, zone.name, soa, opts) do
+      :ok -> :ok
+      {:error, :already_exists} -> :skipped
+      {:error, _} -> :error
+    end
+  end
+
+  defp migrate_zone_to_store(%{type: :forward} = zone) do
+    view = zone[:view_name] || "default"
+
+    forwarders =
+      (zone[:upstreams] || [])
+      |> Enum.flat_map(fn upstream ->
+        case String.split(upstream, ":") do
+          [ip, port_str] ->
+            case Integer.parse(port_str) do
+              {port, ""} -> [%{ip: ip, port: port}]
+              _ -> [%{ip: ip, port: 53}]
+            end
+
+          [ip] ->
+            [%{ip: ip, port: 53}]
+
+          _ ->
+            []
+        end
+      end)
+
+    case YellowDog.Store.Zone.create_forward_zone(view, zone.name, forwarders) do
+      :ok -> :ok
+      {:error, :already_exists} -> :skipped
+      {:error, _} -> :error
+    end
+  end
+
+  defp migrate_zone_to_store(%{type: :stub} = zone) do
+    view = zone[:view_name] || "default"
+
+    primaries =
+      (zone[:ns_records] || [])
+      |> Enum.map(fn ns -> %{ip: ns, port: 53} end)
+
+    case YellowDog.Store.Zone.create_stub_zone(view, zone.name, primaries) do
+      :ok -> :ok
+      {:error, :already_exists} -> :skipped
+      {:error, _} -> :error
+    end
+  end
+
+  defp migrate_zone_to_store(_zone), do: :skipped
 
   @doc """
   Validates a zone configuration.

--- a/apps/yellow_dog_dns/test/yellow_dog/dns/boundaries/zone_service_test.exs
+++ b/apps/yellow_dog_dns/test/yellow_dog/dns/boundaries/zone_service_test.exs
@@ -6,8 +6,12 @@ defmodule YellowDog.Dns.Boundaries.ZoneServiceTest do
   alias DNS.Zone.Validator.Result
 
   setup_all do
-    # Start the ZoneRegistry once for all tests
-    {:ok, _registry_pid} = Registry.start_link(keys: :unique, name: YellowDog.Dns.ZoneRegistry)
+    # Start the ZoneRegistry once for all tests (handle already started)
+    case Registry.start_link(keys: :unique, name: YellowDog.Dns.ZoneRegistry) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
     :ok
   end
 

--- a/apps/yellow_dog_dns/test/yellow_dog/dns/zone/behaviour_test.exs
+++ b/apps/yellow_dog_dns/test/yellow_dog/dns/zone/behaviour_test.exs
@@ -83,10 +83,16 @@ defmodule YellowDog.Dns.Zone.BehaviourTest do
       assert {:stats, 1} in callbacks
     end
 
-    test "has exactly 4 callbacks" do
+    test "defines update_config/2 callback" do
       callbacks = Behaviour.behaviour_info(:callbacks)
 
-      assert length(callbacks) == 4
+      assert {:update_config, 2} in callbacks
+    end
+
+    test "has exactly 5 callbacks" do
+      callbacks = Behaviour.behaviour_info(:callbacks)
+
+      assert length(callbacks) == 5
     end
   end
 

--- a/apps/yellow_dog_dns/test/yellow_dog/dns/zone/store_integration_test.exs
+++ b/apps/yellow_dog_dns/test/yellow_dog/dns/zone/store_integration_test.exs
@@ -13,6 +13,30 @@ defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
   alias YellowDog.Store.Backend.Ets, as: EtsBackend
   alias DNS.Message
 
+  # Poll until condition is true or timeout (avoids brittle Process.sleep)
+  defp assert_eventually(fun, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 500)
+    interval = Keyword.get(opts, :interval, 10)
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    do_assert_eventually(fun, interval, deadline)
+  end
+
+  defp do_assert_eventually(fun, interval, deadline) do
+    case fun.() do
+      true ->
+        :ok
+
+      false ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          flunk("assert_eventually timed out")
+        else
+          Process.sleep(interval)
+          do_assert_eventually(fun, interval, deadline)
+        end
+    end
+  end
+
   setup_all do
     registry_name = YellowDog.Dns.ZoneRegistry
 
@@ -115,10 +139,12 @@ defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
       :ok = Auth.update_config(pid, %{ttl: 7200})
 
       # Wait for async Store sync
-      Process.sleep(100)
-
-      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
-      assert metadata[:default_ttl] == 7200
+      assert_eventually(fn ->
+        case YellowDog.Store.Zone.get_zone(view, zone_name) do
+          {:ok, metadata} -> metadata[:default_ttl] == 7200
+          _ -> false
+        end
+      end)
 
       GenServer.stop(pid, :normal)
     end
@@ -204,10 +230,12 @@ defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
       :ok = Forward.update_config(pid, %{upstreams: [{"9.9.9.9", 53}], timeout: 2000})
 
       # Wait for async sync
-      Process.sleep(100)
-
-      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
-      assert metadata[:timeout_ms] == 2000
+      assert_eventually(fn ->
+        case YellowDog.Store.Zone.get_zone(view, zone_name) do
+          {:ok, metadata} -> metadata[:timeout_ms] == 2000
+          _ -> false
+        end
+      end)
 
       GenServer.stop(pid, :normal)
     end
@@ -230,10 +258,6 @@ defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
 
       {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
       assert length(metadata[:forwarders]) == 2
-
-      GenServer.stop(pid, :normal)
-    catch
-      :exit, _ -> :ok
     end
   end
 
@@ -278,10 +302,12 @@ defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
         })
 
       # Wait for async sync
-      Process.sleep(100)
-
-      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
-      assert metadata[:zone_type] == :stub
+      assert_eventually(fn ->
+        case YellowDog.Store.Zone.get_zone(view, zone_name) do
+          {:ok, metadata} -> metadata[:zone_type] == :stub
+          _ -> false
+        end
+      end)
 
       GenServer.stop(pid, :normal)
     end

--- a/apps/yellow_dog_dns/test/yellow_dog/dns/zone/store_integration_test.exs
+++ b/apps/yellow_dog_dns/test/yellow_dog/dns/zone/store_integration_test.exs
@@ -1,0 +1,289 @@
+defmodule YellowDog.Dns.Zone.StoreIntegrationTest do
+  @moduledoc """
+  Tests Store-backed persistence for all zone types.
+
+  Verifies that zone data survives process restart via Store persistence.
+  """
+  use ExUnit.Case, async: false
+
+  alias YellowDog.Dns.Zone.Auth
+  alias YellowDog.Dns.Zone.Forward
+  alias YellowDog.Dns.Zone.Stub
+  alias YellowDog.Store.Backend
+  alias YellowDog.Store.Backend.Ets, as: EtsBackend
+  alias DNS.Message
+
+  setup_all do
+    registry_name = YellowDog.Dns.ZoneRegistry
+
+    case Process.whereis(registry_name) do
+      nil ->
+        {:ok, _} = Registry.start_link(keys: :unique, name: registry_name)
+
+      _ ->
+        :ok
+    end
+
+    Process.sleep(10)
+    :ok
+  end
+
+  setup do
+    # Set up ETS Store backend for test isolation
+    EtsBackend.create_table()
+    Backend.set_active(EtsBackend)
+
+    table = EtsBackend.table()
+
+    case :ets.whereis(table) do
+      :undefined -> :ok
+      _ref -> :ets.delete_all_objects(table)
+    end
+
+    :ok
+  end
+
+  describe "Auth zone Store persistence" do
+    test "records persist across process restart via Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "persist-#{System.unique_integer([:positive])}.com"
+
+      # Create zone in Store first
+      soa = %{
+        mname: "ns1.#{zone_name}",
+        rname: "admin.#{zone_name}",
+        serial: 1,
+        refresh: 3600,
+        retry: 1800,
+        expire: 604_800,
+        minimum: 86_400
+      }
+
+      :ok = YellowDog.Store.Zone.create_zone(view, zone_name, soa)
+
+      # Start zone (will load from Store since no zone_data/zone_file)
+      {:ok, pid} = Auth.start_link(name: zone_name, view_name: view)
+
+      # Add a record
+      record = Message.Record.new("www.#{zone_name}", :a, :in, 3600, {192, 168, 1, 1})
+      :ok = Auth.add_record(pid, record)
+
+      # Verify record exists
+      records = Auth.get_records(pid, "www.#{zone_name}", :a)
+      assert length(records) == 1
+
+      # Stop gracefully (should flush to Store)
+      GenServer.stop(pid, :normal)
+      Process.sleep(50)
+
+      # Restart zone — should load records from Store
+      {:ok, pid2} = Auth.start_link(name: zone_name, view_name: view)
+      records2 = Auth.get_records(pid2, "www.#{zone_name}", :a)
+      assert length(records2) == 1
+
+      first_record = hd(records2)
+      # DNS.Message.Record.Data.A wraps the tuple — check the inner data field
+      address =
+        case first_record.data do
+          {_, _, _, _} = ip -> ip
+          %{data: ip} -> ip
+          other -> other
+        end
+
+      assert address == {192, 168, 1, 1}
+
+      GenServer.stop(pid2, :normal)
+    end
+
+    test "update_config persists to Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "config-#{System.unique_integer([:positive])}.com"
+
+      soa = %{
+        mname: "ns1.#{zone_name}",
+        rname: "admin.#{zone_name}",
+        serial: 1,
+        refresh: 3600,
+        retry: 1800,
+        expire: 604_800,
+        minimum: 86_400
+      }
+
+      :ok = YellowDog.Store.Zone.create_zone(view, zone_name, soa)
+
+      {:ok, pid} = Auth.start_link(name: zone_name, view_name: view)
+      :ok = Auth.update_config(pid, %{ttl: 7200})
+
+      # Wait for async Store sync
+      Process.sleep(100)
+
+      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
+      assert metadata[:default_ttl] == 7200
+
+      GenServer.stop(pid, :normal)
+    end
+
+    test "reload with empty config loads from Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "reload-#{System.unique_integer([:positive])}.com"
+
+      soa = %{
+        mname: "ns1.#{zone_name}",
+        rname: "admin.#{zone_name}",
+        serial: 1,
+        refresh: 3600,
+        retry: 1800,
+        expire: 604_800,
+        minimum: 86_400
+      }
+
+      :ok = YellowDog.Store.Zone.create_zone(view, zone_name, soa)
+
+      # Put an RRset directly in Store (5th arg is the rrset list)
+      :ok =
+        YellowDog.Store.Zone.put_rrset(
+          view,
+          zone_name,
+          "mail.#{zone_name}",
+          :a,
+          [%{address: "10.0.0.1", ttl: 3600}]
+        )
+
+      # Start zone with explicit empty records
+      {:ok, pid} = Auth.start_link(name: zone_name, view_name: view, zone_data: [])
+
+      # No records yet (started with empty zone_data)
+      assert Auth.get_all_records(pid) == []
+
+      # Reload with empty config → loads from Store
+      :ok = Auth.reload(pid, [])
+
+      records = Auth.get_records(pid, "mail.#{zone_name}", :a)
+      assert length(records) >= 1
+
+      GenServer.stop(pid, :normal)
+    end
+  end
+
+  describe "Forward zone Store persistence" do
+    test "loads config from Store on init when no upstreams provided" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "forward-#{System.unique_integer([:positive])}.com"
+
+      forwarders = [%{ip: "8.8.8.8", port: 53}, %{ip: "8.8.4.4", port: 53}]
+
+      :ok =
+        YellowDog.Store.Zone.create_forward_zone(view, zone_name, forwarders,
+          forward_mode: :only,
+          timeout_ms: 3000,
+          max_retries: 1
+        )
+
+      # Start without explicit upstreams → should load from Store
+      {:ok, pid} = Forward.start_link(name: zone_name, view_name: view)
+
+      stats = Forward.stats(pid)
+      assert stats.upstream_count == 2
+
+      GenServer.stop(pid, :normal)
+    end
+
+    test "update_config persists to Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "fwd-cfg-#{System.unique_integer([:positive])}.com"
+
+      :ok = YellowDog.Store.Zone.create_forward_zone(view, zone_name, [])
+
+      {:ok, pid} =
+        Forward.start_link(
+          name: zone_name,
+          view_name: view,
+          upstreams: [{"1.1.1.1", 53}]
+        )
+
+      :ok = Forward.update_config(pid, %{upstreams: [{"9.9.9.9", 53}], timeout: 2000})
+
+      # Wait for async sync
+      Process.sleep(100)
+
+      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
+      assert metadata[:timeout_ms] == 2000
+
+      GenServer.stop(pid, :normal)
+    end
+
+    test "terminate flushes config to Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "fwd-term-#{System.unique_integer([:positive])}.com"
+
+      :ok = YellowDog.Store.Zone.create_forward_zone(view, zone_name, [])
+
+      {:ok, pid} =
+        Forward.start_link(
+          name: zone_name,
+          view_name: view,
+          upstreams: [{"1.1.1.1", 53}, {"8.8.8.8", 53}]
+        )
+
+      GenServer.stop(pid, :normal)
+      Process.sleep(50)
+
+      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
+      assert length(metadata[:forwarders]) == 2
+
+      GenServer.stop(pid, :normal)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  describe "Stub zone Store persistence" do
+    test "loads config from Store on init when no ns_records provided" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "stub-#{System.unique_integer([:positive])}.com"
+
+      primaries = [%{ip: "10.0.0.1", port: 53}]
+      :ok = YellowDog.Store.Zone.create_stub_zone(view, zone_name, primaries)
+
+      # Start without explicit ns_records → should load from Store
+      {:ok, pid} = Stub.start_link(name: zone_name, view_name: view)
+
+      stats = Stub.stats(pid)
+      assert stats.ns_count >= 1
+
+      GenServer.stop(pid, :normal)
+    end
+
+    test "update_config persists to Store" do
+      view = "test_view_#{System.unique_integer([:positive])}"
+      zone_name = "stub-cfg-#{System.unique_integer([:positive])}.com"
+
+      :ok = YellowDog.Store.Zone.create_stub_zone(view, zone_name, [])
+
+      {:ok, pid} =
+        Stub.start_link(
+          name: zone_name,
+          view_name: view,
+          ns_records: ["ns1.#{zone_name}"],
+          glue_records: %{"ns1.#{zone_name}" => {10, 0, 0, 1}}
+        )
+
+      :ok =
+        Stub.update_config(pid, %{
+          ns_records: ["ns1.#{zone_name}", "ns2.#{zone_name}"],
+          glue_records: %{
+            "ns1.#{zone_name}" => {10, 0, 0, 1},
+            "ns2.#{zone_name}" => {10, 0, 0, 2}
+          }
+        })
+
+      # Wait for async sync
+      Process.sleep(100)
+
+      {:ok, metadata} = YellowDog.Store.Zone.get_zone(view, zone_name)
+      assert metadata[:zone_type] == :stub
+
+      GenServer.stop(pid, :normal)
+    end
+  end
+end

--- a/apps/yellow_dog_netman/lib/yellow_dog/netman/console/client.ex
+++ b/apps/yellow_dog_netman/lib/yellow_dog/netman/console/client.ex
@@ -624,8 +624,7 @@ defmodule YellowDog.Netman.Console.Client do
       domain: metadata.domain,
       type: metadata.type,
       source: metadata.source,
-      duration_us:
-        System.convert_time_unit(measurements[:duration] || 0, :native, :microsecond)
+      duration_us: System.convert_time_unit(measurements[:duration] || 0, :native, :microsecond)
     }
 
     send(config.pid, {:resolved_query, entry})

--- a/apps/yellow_dog_netman/test/integration/concurrent_shutdown_test.exs
+++ b/apps/yellow_dog_netman/test/integration/concurrent_shutdown_test.exs
@@ -88,8 +88,12 @@ defmodule YellowDog.Netman.Integration.ConcurrentShutdownTest do
     Enum.each(ifaces, fn iface ->
       Enum.reduce_while(1..20, :waiting, fn _, _ ->
         case Connection.Supervisor.find_connection(iface) do
-          :error -> {:halt, :gone}
-          {:ok, _} -> Process.sleep(100); {:cont, :waiting}
+          :error ->
+            {:halt, :gone}
+
+          {:ok, _} ->
+            Process.sleep(100)
+            {:cont, :waiting}
         end
       end)
 

--- a/apps/yellow_dog_store/lib/yellow_dog/store.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store.ex
@@ -40,19 +40,34 @@ defmodule YellowDog.Store do
   defdelegate devices_by_vendor(vendor_class), to: YellowDog.Store.Device, as: :by_vendor
   defdelegate recent_devices(since), to: YellowDog.Store.Device, as: :list_recent
 
-  # Zone operations
-  defdelegate create_zone(name, soa, opts \\ []), to: YellowDog.Store.Zone
-  defdelegate delete_zone(name), to: YellowDog.Store.Zone
-  defdelegate get_zone(name), to: YellowDog.Store.Zone
+  # Zone operations (view-scoped)
+  defdelegate create_zone(view_name, name, soa, opts \\ []), to: YellowDog.Store.Zone
+  defdelegate delete_zone(view_name, name), to: YellowDog.Store.Zone
+  defdelegate get_zone(view_name, name), to: YellowDog.Store.Zone
   defdelegate list_zones(), to: YellowDog.Store.Zone
-  defdelegate put_rrset(zone, owner, type, rrset), to: YellowDog.Store.Zone
-  defdelegate get_rrset(zone, owner, type), to: YellowDog.Store.Zone
-  defdelegate delete_rrset(zone, owner, type), to: YellowDog.Store.Zone
-  defdelegate list_records(zone), to: YellowDog.Store.Zone
-  defdelegate list_records(zone, owner), to: YellowDog.Store.Zone
-  defdelegate import_zone(name, records), to: YellowDog.Store.Zone, as: :import
-  defdelegate export_zone(name), to: YellowDog.Store.Zone, as: :export
-  defdelegate increment_serial(name), to: YellowDog.Store.Zone
+  defdelegate list_zones_for_view(view_name), to: YellowDog.Store.Zone
+  defdelegate list_zones_by_type(zone_type), to: YellowDog.Store.Zone
+  defdelegate update_zone(view_name, name, attrs), to: YellowDog.Store.Zone
+  defdelegate put_rrset(view_name, zone, owner, type, rrset), to: YellowDog.Store.Zone
+  defdelegate get_rrset(view_name, zone, owner, type), to: YellowDog.Store.Zone
+  defdelegate delete_rrset(view_name, zone, owner, type), to: YellowDog.Store.Zone
+  defdelegate list_records(view_name, zone), to: YellowDog.Store.Zone
+  defdelegate list_records(view_name, zone, owner), to: YellowDog.Store.Zone
+  defdelegate import_zone(view_name, name, records), to: YellowDog.Store.Zone
+  defdelegate export_zone(view_name, name), to: YellowDog.Store.Zone
+  defdelegate increment_serial(view_name, name), to: YellowDog.Store.Zone
+
+  # Forward zone operations
+  defdelegate create_forward_zone(view_name, name, forwarders, opts \\ []),
+    to: YellowDog.Store.Zone
+
+  defdelegate update_forward_zone(view_name, name, attrs), to: YellowDog.Store.Zone
+
+  # Stub zone operations
+  defdelegate create_stub_zone(view_name, name, primaries, opts \\ []),
+    to: YellowDog.Store.Zone
+
+  defdelegate update_stub_zone(view_name, name, attrs), to: YellowDog.Store.Zone
 
   # DynDns operations
   defdelegate put_dyn_dns(fqdn, record, opts \\ []), to: YellowDog.Store.DynDns, as: :put

--- a/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
@@ -96,7 +96,7 @@ defmodule YellowDog.Store.Key do
     do: "dns:view:#{view_name}:zone:#{zone_name}:rr:"
 
   @deprecated "Use zone_prefix/1 with view_name or all_views_prefix/0"
-  def zone_prefix, do: "dns:zone:"
+  def zone_prefix, do: zone_prefix("default")
 
   @deprecated "Use zone_rr_prefix/2 with view_name"
   def zone_rr_prefix(zone_name), do: zone_rr_prefix("default", zone_name)

--- a/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
@@ -36,13 +36,24 @@ defmodule YellowDog.Store.Key do
   @spec dyn_dns_ptr(String.t()) :: String.t()
   def dyn_dns_ptr(arpa), do: "dns:dyn:ptr:#{arpa}"
 
-  @doc "Zone metadata key."
-  @spec zone(String.t()) :: String.t()
-  def zone(name), do: "dns:zone:#{name}"
+  @doc "Zone metadata key (view-scoped)."
+  @spec zone(String.t(), String.t()) :: String.t()
+  def zone(view_name, zone_name), do: "dns:view:#{view_name}:zone:#{zone_name}"
 
-  @doc "Zone resource record key."
+  @doc "Zone metadata key (legacy, default view)."
+  @deprecated "Use zone/2 with explicit view_name"
+  @spec zone(String.t()) :: String.t()
+  def zone(name), do: zone("default", name)
+
+  @doc "Zone resource record key (view-scoped)."
+  @spec zone_rr(String.t(), String.t(), String.t(), atom()) :: String.t()
+  def zone_rr(view_name, zone_name, owner, type),
+    do: "dns:view:#{view_name}:zone:#{zone_name}:rr:#{owner}:#{type}"
+
+  @doc "Zone resource record key (legacy, default view)."
+  @deprecated "Use zone_rr/4 with explicit view_name"
   @spec zone_rr(String.t(), String.t(), atom()) :: String.t()
-  def zone_rr(zone_name, owner, type), do: "dns:zone:#{zone_name}:rr:#{owner}:#{type}"
+  def zone_rr(zone_name, owner, type), do: zone_rr("default", zone_name, owner, type)
 
   @doc "DNS cache key."
   @spec cache(String.t(), atom()) :: String.t()
@@ -65,12 +76,31 @@ defmodule YellowDog.Store.Key do
   def event_log(timestamp, key), do: "event_log:#{timestamp}:#{key}"
 
   # Key prefix constants for prefix scans
+
   def lease_v4_prefix, do: "dhcp:lease:v4:"
   def lease_v6_prefix, do: "dhcp:lease:v6:"
   def device_prefix, do: "device:"
   def dyn_dns_prefix, do: "dns:dyn:"
+
+  @doc "Prefix for all zones across all views."
+  def all_views_prefix, do: "dns:view:"
+
+  @doc "Prefix for a specific view."
+  def view_prefix(view_name), do: "dns:view:#{view_name}:"
+
+  @doc "Prefix for all zones in a view."
+  def zone_prefix(view_name), do: "dns:view:#{view_name}:zone:"
+
+  @doc "Prefix for all RRsets in a zone (view-scoped)."
+  def zone_rr_prefix(view_name, zone_name),
+    do: "dns:view:#{view_name}:zone:#{zone_name}:rr:"
+
+  @deprecated "Use zone_prefix/1 with view_name or all_views_prefix/0"
   def zone_prefix, do: "dns:zone:"
-  def zone_rr_prefix(zone_name), do: "dns:zone:#{zone_name}:rr:"
+
+  @deprecated "Use zone_rr_prefix/2 with view_name"
+  def zone_rr_prefix(zone_name), do: zone_rr_prefix("default", zone_name)
+
   def cache_prefix, do: "dns:cache:"
   def rpz_prefix(zone_name), do: "rpz:#{zone_name}:"
   def rpz_all_prefix, do: "rpz:"

--- a/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/key.ex
@@ -98,6 +98,10 @@ defmodule YellowDog.Store.Key do
   @deprecated "Use zone_prefix/1 with view_name or all_views_prefix/0"
   def zone_prefix, do: zone_prefix("default")
 
+  @doc "Prefix for all RRsets of a specific owner in a zone (view-scoped)."
+  def zone_rr_owner_prefix(view_name, zone_name, owner),
+    do: "dns:view:#{view_name}:zone:#{zone_name}:rr:#{owner}:"
+
   @deprecated "Use zone_rr_prefix/2 with view_name"
   def zone_rr_prefix(zone_name), do: zone_rr_prefix("default", zone_name)
 

--- a/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
@@ -614,10 +614,10 @@ defmodule YellowDog.Store.Zone do
   def default_soa(name) do
     %{
       mname: "ns1.#{name}",
-      rname: "admin.#{name}",
+      rname: "hostmaster.#{name}",
       serial: 1,
       refresh: 3600,
-      retry: 900,
+      retry: 1800,
       expire: 604_800,
       minimum: 86_400
     }

--- a/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
@@ -279,7 +279,11 @@ defmodule YellowDog.Store.Zone do
         zones =
           entries
           |> Enum.filter(fn {key, _value} -> zone_metadata_key?(key) end)
-          |> Enum.map(fn {_key, value} -> value end)
+          |> Enum.map(fn {key, value} ->
+            # Inject view_name from key: dns:view:{view_name}:zone:{zone_name}
+            view_name = extract_view_name_from_key(key)
+            Map.put(value, :view_name, view_name)
+          end)
 
         emit_operation_telemetry(start_time, :zone, :list, prefix, :eventual)
         {:ok, zones}
@@ -302,7 +306,7 @@ defmodule YellowDog.Store.Zone do
         zones =
           entries
           |> Enum.filter(fn {key, _value} -> zone_metadata_key?(key) end)
-          |> Enum.map(fn {_key, value} -> value end)
+          |> Enum.map(fn {_key, value} -> Map.put(value, :view_name, view_name) end)
 
         emit_operation_telemetry(start_time, :zone, :list, prefix, :eventual)
         {:ok, zones}
@@ -580,6 +584,15 @@ defmodule YellowDog.Store.Zone do
     case String.split(key, ":zone:", parts: 2) do
       [_prefix, suffix] -> not String.contains?(suffix, ":")
       _ -> false
+    end
+  end
+
+  # Extract view_name from key: "dns:view:{view_name}:zone:{zone_name}"
+  defp extract_view_name_from_key(key) do
+    case String.split(key, ":") do
+      ["dns", "view", view_name, "zone", _zone_name] -> view_name
+      ["dns", "view", view_name | _rest] -> view_name
+      _ -> "default"
     end
   end
 

--- a/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
@@ -1,19 +1,22 @@
 defmodule YellowDog.Store.Zone do
   @moduledoc """
-  Authoritative DNS zone data facade over the Store backend.
+  DNS zone data facade over the Store backend.
 
-  Manages zone metadata and resource record sets (RRsets). Zone creation
-  uses CAS (`expected: nil`) to prevent duplicates. RRset writes use
-  upsert semantics (last-writer-wins). SOA serial auto-increment uses
-  CAS with bounded retries to prevent lost updates.
+  Manages zone metadata and resource record sets (RRsets) for all zone types:
+  auth, forward, and stub. All zones are scoped to views (split-horizon DNS).
+
+  Zone creation uses CAS (`expected: nil`) to prevent duplicates. RRset writes
+  use upsert semantics (last-writer-wins). SOA serial auto-increment uses CAS
+  with bounded retries to prevent lost updates.
 
   Key patterns (via `YellowDog.Store.Key`):
-  - Zone metadata: `dns:zone:{zone_name}`
-  - Resource records: `dns:zone:{zone_name}:rr:{owner}:{type}`
+  - Zone metadata: `dns:view:{view_name}:zone:{zone_name}`
+  - Resource records (auth only): `dns:view:{view_name}:zone:{zone_name}:rr:{owner}:{type}`
   """
 
   alias YellowDog.Store.{Backend, EventBridge, Key}
 
+  @type view_name :: String.t()
   @type zone_name :: String.t()
   @type owner :: String.t()
   @type rr_type :: atom()
@@ -27,14 +30,12 @@ defmodule YellowDog.Store.Zone do
           minimum: pos_integer()
         }
 
-  @zone_prefix "dns:zone:"
-
   # -------------------------------------------------------------------
-  # Zone metadata
+  # Auth zone metadata
   # -------------------------------------------------------------------
 
   @doc """
-  Create zone metadata. Fails if the zone already exists (CAS with `expected: nil`).
+  Create an auth zone. Fails if the zone already exists (CAS with `expected: nil`).
 
   ## Options
 
@@ -43,12 +44,14 @@ defmodule YellowDog.Store.Zone do
     * `:allow_dynamic_update` - accept RFC 2136 dynamic updates (default `false`)
     * `:serial_strategy` - `:date_serial` or `:increment` (default `:date_serial`)
   """
-  @spec create_zone(zone_name(), soa(), keyword()) :: :ok | {:error, :already_exists | term()}
-  def create_zone(name, soa, opts \\ []) do
-    key = Key.zone(name)
+  @spec create_zone(view_name(), zone_name(), soa(), keyword()) ::
+          :ok | {:error, :already_exists | term()}
+  def create_zone(view_name, name, soa, opts \\ []) do
+    key = Key.zone(view_name, name)
     now = System.system_time(:second)
 
     value = %{
+      zone_type: :auth,
       origin: name,
       soa: soa,
       default_ttl: Keyword.get(opts, :default_ttl, 3600),
@@ -75,25 +78,130 @@ defmodule YellowDog.Store.Zone do
     end
   end
 
+  # -------------------------------------------------------------------
+  # Forward zone
+  # -------------------------------------------------------------------
+
   @doc """
-  Delete a zone and all its resource records.
+  Create a forward zone. Stores config only (no zone data).
+
+  ## Options
+
+    * `:forward_mode` - `:only` or `:first` (default `:only`)
+    * `:timeout_ms` - forwarding timeout in ms (default `5000`)
+    * `:max_retries` - max retry count (default `2`)
   """
-  @spec delete_zone(zone_name()) :: :ok | {:error, term()}
-  def delete_zone(name) do
-    zone_key = Key.zone(name)
+  @spec create_forward_zone(view_name(), zone_name(), [map()], keyword()) ::
+          :ok | {:error, :already_exists | term()}
+  def create_forward_zone(view_name, name, forwarders, opts \\ []) do
+    key = Key.zone(view_name, name)
+    now = System.system_time(:second)
+
+    value = %{
+      zone_type: :forward,
+      origin: name,
+      forwarders: forwarders,
+      forward_mode: Keyword.get(opts, :forward_mode, :only),
+      timeout_ms: Keyword.get(opts, :timeout_ms, 5000),
+      max_retries: Keyword.get(opts, :max_retries, 2),
+      created_at: now,
+      updated_at: now
+    }
+
     start_time = System.monotonic_time()
 
-    # Delete zone metadata first so the zone appears "gone" immediately,
-    # even if RR cleanup is interrupted by a crash.
+    case Backend.active().put_if(key, value, expected: nil) do
+      :ok ->
+        emit_operation_telemetry(start_time, :zone, :put, key, :strong)
+        EventBridge.notify(:put, key, value)
+        :ok
+
+      {:error, :condition_failed} ->
+        {:error, :already_exists}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Update a forward zone's configuration. CAS update.
+  """
+  @spec update_forward_zone(view_name(), zone_name(), map()) :: :ok | {:error, term()}
+  def update_forward_zone(view_name, name, attrs) do
+    update_zone(view_name, name, attrs)
+  end
+
+  # -------------------------------------------------------------------
+  # Stub zone
+  # -------------------------------------------------------------------
+
+  @doc """
+  Create a stub zone. Stores config only (NS/glue are runtime cache).
+
+  ## Options
+
+    * `:refresh_interval` - how often to re-query primaries in seconds (default `3600`)
+  """
+  @spec create_stub_zone(view_name(), zone_name(), [map()], keyword()) ::
+          :ok | {:error, :already_exists | term()}
+  def create_stub_zone(view_name, name, primaries, opts \\ []) do
+    key = Key.zone(view_name, name)
+    now = System.system_time(:second)
+
+    value = %{
+      zone_type: :stub,
+      origin: name,
+      primaries: primaries,
+      refresh_interval: Keyword.get(opts, :refresh_interval, 3600),
+      created_at: now,
+      updated_at: now
+    }
+
+    start_time = System.monotonic_time()
+
+    case Backend.active().put_if(key, value, expected: nil) do
+      :ok ->
+        emit_operation_telemetry(start_time, :zone, :put, key, :strong)
+        EventBridge.notify(:put, key, value)
+        :ok
+
+      {:error, :condition_failed} ->
+        {:error, :already_exists}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Update a stub zone's configuration. CAS update.
+  """
+  @spec update_stub_zone(view_name(), zone_name(), map()) :: :ok | {:error, term()}
+  def update_stub_zone(view_name, name, attrs) do
+    update_zone(view_name, name, attrs)
+  end
+
+  # -------------------------------------------------------------------
+  # Generic zone operations (all types)
+  # -------------------------------------------------------------------
+
+  @doc """
+  Delete a zone and all its resource records (for auth zones).
+  Works for all zone types.
+  """
+  @spec delete_zone(view_name(), zone_name()) :: :ok | {:error, term()}
+  def delete_zone(view_name, name) do
+    zone_key = Key.zone(view_name, name)
+    start_time = System.monotonic_time()
+
     case Backend.active().delete(zone_key) do
       :ok ->
         emit_operation_telemetry(start_time, :zone, :delete, zone_key, :strong)
         EventBridge.notify(:delete, zone_key, nil)
 
-        # Best-effort cleanup of RR entries (orphans are harmless —
-        # they are invisible without zone metadata and will be collected
-        # by periodic GC or overwritten on zone re-creation).
-        rr_prefix = Key.zone_rr_prefix(name)
+        # Best-effort cleanup of RR entries for auth zones
+        rr_prefix = Key.zone_rr_prefix(view_name, name)
 
         case Backend.active().prefix_scan(rr_prefix, consistency: :strong) do
           {:ok, rr_entries} ->
@@ -115,9 +223,9 @@ defmodule YellowDog.Store.Zone do
   @doc """
   Get zone metadata. Uses `:eventual` consistency.
   """
-  @spec get_zone(zone_name()) :: {:ok, map()} | {:error, :not_found | term()}
-  def get_zone(name) do
-    key = Key.zone(name)
+  @spec get_zone(view_name(), zone_name()) :: {:ok, map()} | {:error, :not_found | term()}
+  def get_zone(view_name, name) do
+    key = Key.zone(view_name, name)
     start_time = System.monotonic_time()
     result = Backend.active().get(key, consistency: :eventual)
     emit_operation_telemetry(start_time, :zone, :get, key, :eventual)
@@ -125,23 +233,94 @@ defmodule YellowDog.Store.Zone do
   end
 
   @doc """
-  List all zone names. Scans the `dns:zone:` prefix and filters to
-  metadata-only keys (excludes RR sub-keys).
+  Update zone metadata (any zone type). Merges `attrs` into existing metadata.
+  Uses CAS to prevent lost updates.
   """
-  @spec list_zones() :: {:ok, [zone_name()]} | {:error, term()}
+  @spec update_zone(view_name(), zone_name(), map()) :: :ok | {:error, term()}
+  def update_zone(view_name, name, attrs) do
+    key = Key.zone(view_name, name)
+
+    case Backend.active().get(key, consistency: :strong) do
+      {:ok, zone_meta} ->
+        now = System.system_time(:second)
+
+        updated_meta =
+          zone_meta
+          |> Map.merge(attrs)
+          |> Map.put(:updated_at, now)
+
+        case Backend.active().put_if(key, updated_meta, condition: fn old -> old == zone_meta end) do
+          :ok ->
+            EventBridge.notify(:put, key, updated_meta)
+            :ok
+
+          {:error, :condition_failed} ->
+            {:error, :conflict}
+
+          {:error, _} = error ->
+            error
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  List all zones across all views. Returns a list of zone metadata maps.
+  """
+  @spec list_zones() :: {:ok, [map()]} | {:error, term()}
   def list_zones do
+    prefix = Key.all_views_prefix()
     start_time = System.monotonic_time()
 
-    case Backend.active().prefix_scan(@zone_prefix, consistency: :eventual) do
+    case Backend.active().prefix_scan(prefix, consistency: :eventual) do
       {:ok, entries} ->
-        names =
+        zones =
           entries
-          |> Enum.map(fn {key, _value} -> key end)
-          |> Enum.filter(&zone_metadata_key?/1)
-          |> Enum.map(&extract_zone_name/1)
+          |> Enum.filter(fn {key, _value} -> zone_metadata_key?(key) end)
+          |> Enum.map(fn {_key, value} -> value end)
 
-        emit_operation_telemetry(start_time, :zone, :list, @zone_prefix, :eventual)
-        {:ok, names}
+        emit_operation_telemetry(start_time, :zone, :list, prefix, :eventual)
+        {:ok, zones}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  List all zones in a specific view.
+  """
+  @spec list_zones_for_view(view_name()) :: {:ok, [map()]} | {:error, term()}
+  def list_zones_for_view(view_name) do
+    prefix = Key.zone_prefix(view_name)
+    start_time = System.monotonic_time()
+
+    case Backend.active().prefix_scan(prefix, consistency: :eventual) do
+      {:ok, entries} ->
+        zones =
+          entries
+          |> Enum.filter(fn {key, _value} -> zone_metadata_key?(key) end)
+          |> Enum.map(fn {_key, value} -> value end)
+
+        emit_operation_telemetry(start_time, :zone, :list, prefix, :eventual)
+        {:ok, zones}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  List all zones of a specific type across all views.
+  """
+  @spec list_zones_by_type(atom()) :: {:ok, [map()]} | {:error, term()}
+  def list_zones_by_type(zone_type) do
+    case list_zones() do
+      {:ok, zones} ->
+        filtered = Enum.filter(zones, fn z -> z[:zone_type] == zone_type end)
+        {:ok, filtered}
 
       {:error, _} = error ->
         error
@@ -149,20 +328,16 @@ defmodule YellowDog.Store.Zone do
   end
 
   # -------------------------------------------------------------------
-  # Resource records
+  # Resource records (auth zones only)
   # -------------------------------------------------------------------
 
   @doc """
-  Create or update an RRset. Uses CAS to prevent concurrent edit races.
-  Auto-increments the SOA serial on success.
-
-  `rrset` is a list of record maps, each containing at least `:rdata` and
-  optionally `:ttl`.
+  Create or update an RRset. Auto-increments the SOA serial on success.
   """
-  @spec put_rrset(zone_name(), owner(), rr_type(), list(map())) ::
+  @spec put_rrset(view_name(), zone_name(), owner(), rr_type(), list(map())) ::
           :ok | {:error, term()}
-  def put_rrset(zone, owner, type, rrset) do
-    key = Key.zone_rr(zone, owner, type)
+  def put_rrset(view_name, zone, owner, type, rrset) do
+    key = Key.zone_rr(view_name, zone, owner, type)
     now = System.system_time(:second)
 
     value = %{
@@ -177,8 +352,6 @@ defmodule YellowDog.Store.Zone do
 
     start_time = System.monotonic_time()
 
-    # Upsert: create or overwrite. SOA serial increment provides
-    # zone-level change detection for downstream consumers.
     result = Backend.active().put(key, value)
 
     case result do
@@ -186,7 +359,7 @@ defmodule YellowDog.Store.Zone do
         emit_operation_telemetry(start_time, :zone, :put, key, :strong)
         emit_rr_changed(zone, owner, type, :put)
         EventBridge.notify(:put, key, value)
-        increment_serial(zone)
+        increment_serial(view_name, zone)
         :ok
 
       {:error, _} = error ->
@@ -197,10 +370,10 @@ defmodule YellowDog.Store.Zone do
   @doc """
   Lookup a specific RRset. Uses `:eventual` consistency.
   """
-  @spec get_rrset(zone_name(), owner(), rr_type()) ::
+  @spec get_rrset(view_name(), zone_name(), owner(), rr_type()) ::
           {:ok, map()} | {:error, :not_found | term()}
-  def get_rrset(zone, owner, type) do
-    key = Key.zone_rr(zone, owner, type)
+  def get_rrset(view_name, zone, owner, type) do
+    key = Key.zone_rr(view_name, zone, owner, type)
     start_time = System.monotonic_time()
     result = Backend.active().get(key, consistency: :eventual)
     emit_operation_telemetry(start_time, :zone, :get, key, :eventual)
@@ -210,9 +383,9 @@ defmodule YellowDog.Store.Zone do
   @doc """
   Remove an RRset. Auto-increments the SOA serial on success.
   """
-  @spec delete_rrset(zone_name(), owner(), rr_type()) :: :ok | {:error, term()}
-  def delete_rrset(zone, owner, type) do
-    key = Key.zone_rr(zone, owner, type)
+  @spec delete_rrset(view_name(), zone_name(), owner(), rr_type()) :: :ok | {:error, term()}
+  def delete_rrset(view_name, zone, owner, type) do
+    key = Key.zone_rr(view_name, zone, owner, type)
     start_time = System.monotonic_time()
 
     case Backend.active().delete(key) do
@@ -220,7 +393,7 @@ defmodule YellowDog.Store.Zone do
         emit_operation_telemetry(start_time, :zone, :delete, key, :strong)
         emit_rr_changed(zone, owner, type, :delete)
         EventBridge.notify(:delete, key, nil)
-        increment_serial(zone)
+        increment_serial(view_name, zone)
         :ok
 
       {:error, _} = error ->
@@ -231,9 +404,9 @@ defmodule YellowDog.Store.Zone do
   @doc """
   List all RRsets in a zone via prefix scan.
   """
-  @spec list_records(zone_name()) :: {:ok, [map()]} | {:error, term()}
-  def list_records(zone) do
-    prefix = Key.zone_rr_prefix(zone)
+  @spec list_records(view_name(), zone_name()) :: {:ok, [map()]} | {:error, term()}
+  def list_records(view_name, zone) do
+    prefix = Key.zone_rr_prefix(view_name, zone)
     start_time = System.monotonic_time()
 
     case Backend.active().prefix_scan(prefix, consistency: :eventual) do
@@ -250,9 +423,9 @@ defmodule YellowDog.Store.Zone do
   @doc """
   List all RRsets for a specific owner name in a zone.
   """
-  @spec list_records(zone_name(), owner()) :: {:ok, [map()]} | {:error, term()}
-  def list_records(zone, owner) do
-    case list_records(zone) do
+  @spec list_records(view_name(), zone_name(), owner()) :: {:ok, [map()]} | {:error, term()}
+  def list_records(view_name, zone, owner) do
+    case list_records(view_name, zone) do
       {:ok, records} ->
         filtered = Enum.filter(records, fn r -> r.owner == owner end)
         {:ok, filtered}
@@ -267,14 +440,10 @@ defmodule YellowDog.Store.Zone do
   # -------------------------------------------------------------------
 
   @doc """
-  Import pre-parsed records into a zone. Creates the zone metadata and
-  writes each record as an RRset key.
-
-  `records` is a list of maps, each with `:owner`, `:type`, and `:rrset` keys.
-  Full zone file parsing is out of scope for this facade.
+  Import pre-parsed records into an auth zone.
   """
-  @spec import(zone_name(), list(map())) :: :ok | {:error, term()}
-  def import(name, records) when is_list(records) do
+  @spec import_zone(view_name(), zone_name(), list(map())) :: :ok | {:error, term()}
+  def import_zone(view_name, name, records) when is_list(records) do
     soa =
       records
       |> Enum.find(fn r -> r[:type] == :soa end)
@@ -283,7 +452,7 @@ defmodule YellowDog.Store.Zone do
         _ -> default_soa(name)
       end
 
-    case create_zone(name, soa) do
+    case create_zone(view_name, name, soa) do
       :ok -> :ok
       {:error, :already_exists} -> :ok
       {:error, _} = error -> throw(error)
@@ -292,7 +461,7 @@ defmodule YellowDog.Store.Zone do
     now = System.system_time(:second)
 
     Enum.each(records, fn record ->
-      key = Key.zone_rr(name, record.owner, record.type)
+      key = Key.zone_rr(view_name, name, record.owner, record.type)
 
       value = %{
         rrset: record.rrset,
@@ -319,37 +488,33 @@ defmodule YellowDog.Store.Zone do
   end
 
   @doc """
-  Export all records in a zone as a list of maps. Formatting into zone
-  file text is the caller's responsibility.
+  Export all records in a zone as a list of maps.
   """
-  @spec export(zone_name()) :: {:ok, [map()]} | {:error, term()}
-  def export(name) do
-    list_records(name)
+  @spec export_zone(view_name(), zone_name()) :: {:ok, [map()]} | {:error, term()}
+  def export_zone(view_name, name) do
+    list_records(view_name, name)
   end
 
   # -------------------------------------------------------------------
   # SOA serial management
   # -------------------------------------------------------------------
 
-  @doc """
-  Increment the SOA serial in the zone metadata. Uses date-based serial
-  (YYYYMMDDNN) when the strategy is `:date_serial`, otherwise simple
-  increment.
-
-  Uses CAS to prevent lost updates.
-  """
   @max_cas_retries 10
 
-  @spec increment_serial(zone_name()) :: :ok | {:error, term()}
-  def increment_serial(name), do: increment_serial(name, @max_cas_retries)
+  @doc """
+  Increment the SOA serial in the zone metadata. Uses CAS to prevent lost updates.
+  """
+  @spec increment_serial(view_name(), zone_name()) :: :ok | {:error, term()}
+  def increment_serial(view_name, name),
+    do: do_increment_serial(view_name, name, @max_cas_retries)
 
-  defp increment_serial(_name, 0), do: {:error, :max_retries}
+  defp do_increment_serial(_view_name, _name, 0), do: {:error, :max_retries}
 
-  defp increment_serial(name, retries) do
-    key = Key.zone(name)
+  defp do_increment_serial(view_name, name, retries) do
+    key = Key.zone(view_name, name)
 
     case Backend.active().get(key, consistency: :strong) do
-      {:ok, zone_meta} ->
+      {:ok, %{zone_type: :auth} = zone_meta} ->
         old_serial = zone_meta.soa.serial
         strategy = Map.get(zone_meta, :serial_strategy, :date_serial)
         new_serial = next_serial(old_serial, strategy)
@@ -373,11 +538,15 @@ defmodule YellowDog.Store.Zone do
             :ok
 
           {:error, :condition_failed} ->
-            increment_serial(name, retries - 1)
+            do_increment_serial(view_name, name, retries - 1)
 
           {:error, _} = error ->
             error
         end
+
+      {:ok, _non_auth} ->
+        # Non-auth zones don't have SOA serials
+        :ok
 
       {:error, :not_found} ->
         {:error, :zone_not_found}
@@ -404,13 +573,14 @@ defmodule YellowDog.Store.Zone do
 
   defp next_serial(current, :increment), do: current + 1
 
+  # A zone metadata key has the form dns:view:{v}:zone:{name}
+  # An RR key has dns:view:{v}:zone:{name}:rr:{owner}:{type}
+  # We distinguish them by checking that after "zone:" there's no further ":"
   defp zone_metadata_key?(key) do
-    suffix = String.replace_prefix(key, @zone_prefix, "")
-    not String.contains?(suffix, ":")
-  end
-
-  defp extract_zone_name(key) do
-    String.replace_prefix(key, @zone_prefix, "")
+    case String.split(key, ":zone:", parts: 2) do
+      [_prefix, suffix] -> not String.contains?(suffix, ":")
+      _ -> false
+    end
   end
 
   defp default_soa(name) do

--- a/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
+++ b/apps/yellow_dog_store/lib/yellow_dog/store/zone.ex
@@ -205,12 +205,22 @@ defmodule YellowDog.Store.Zone do
 
         case Backend.active().prefix_scan(rr_prefix, consistency: :strong) do
           {:ok, rr_entries} ->
-            Enum.each(rr_entries, fn {rr_key, _value} ->
-              Backend.active().delete(rr_key)
-            end)
+            failed =
+              Enum.count(rr_entries, fn {rr_key, _value} ->
+                Backend.active().delete(rr_key) != :ok
+              end)
 
-          {:error, _} ->
-            :ok
+            if failed > 0 do
+              require Logger
+
+              Logger.warning(
+                "Zone #{name}: #{failed}/#{length(rr_entries)} RR keys failed to delete"
+              )
+            end
+
+          {:error, scan_error} ->
+            require Logger
+            Logger.warning("Zone #{name}: RR cleanup scan failed: #{inspect(scan_error)}")
         end
 
         :ok
@@ -236,8 +246,15 @@ defmodule YellowDog.Store.Zone do
   Update zone metadata (any zone type). Merges `attrs` into existing metadata.
   Uses CAS to prevent lost updates.
   """
+  @max_update_retries 5
+
   @spec update_zone(view_name(), zone_name(), map()) :: :ok | {:error, term()}
-  def update_zone(view_name, name, attrs) do
+  def update_zone(view_name, name, attrs),
+    do: do_update_zone(view_name, name, attrs, @max_update_retries)
+
+  defp do_update_zone(_view_name, _name, _attrs, 0), do: {:error, :conflict}
+
+  defp do_update_zone(view_name, name, attrs, retries) do
     key = Key.zone(view_name, name)
 
     case Backend.active().get(key, consistency: :strong) do
@@ -255,7 +272,7 @@ defmodule YellowDog.Store.Zone do
             :ok
 
           {:error, :condition_failed} ->
-            {:error, :conflict}
+            do_update_zone(view_name, name, attrs, retries - 1)
 
           {:error, _} = error ->
             error
@@ -429,10 +446,14 @@ defmodule YellowDog.Store.Zone do
   """
   @spec list_records(view_name(), zone_name(), owner()) :: {:ok, [map()]} | {:error, term()}
   def list_records(view_name, zone, owner) do
-    case list_records(view_name, zone) do
-      {:ok, records} ->
-        filtered = Enum.filter(records, fn r -> r.owner == owner end)
-        {:ok, filtered}
+    prefix = Key.zone_rr_owner_prefix(view_name, zone, owner)
+    start_time = System.monotonic_time()
+
+    case Backend.active().prefix_scan(prefix, consistency: :eventual) do
+      {:ok, entries} ->
+        records = Enum.map(entries, fn {_key, value} -> value end)
+        emit_operation_telemetry(start_time, :zone, :list, prefix, :eventual)
+        {:ok, records}
 
       {:error, _} = error ->
         error
@@ -456,39 +477,34 @@ defmodule YellowDog.Store.Zone do
         _ -> default_soa(name)
       end
 
-    case create_zone(view_name, name, soa) do
-      :ok -> :ok
-      {:error, :already_exists} -> :ok
-      {:error, _} = error -> throw(error)
+    with result when result in [:ok, {:error, :already_exists}] <-
+           create_zone(view_name, name, soa) do
+      now = System.system_time(:second)
+
+      Enum.each(records, fn record ->
+        key = Key.zone_rr(view_name, name, record.owner, record.type)
+
+        value = %{
+          rrset: record.rrset,
+          owner: record.owner,
+          type: record.type,
+          zone: name,
+          class: :in,
+          source: :import,
+          updated_at: now
+        }
+
+        Backend.active().put(key, value, consistency: :strong)
+      end)
+
+      :telemetry.execute(
+        [:yellow_dog, :store, :zone, :imported],
+        %{},
+        %{zone: name, record_count: length(records)}
+      )
+
+      :ok
     end
-
-    now = System.system_time(:second)
-
-    Enum.each(records, fn record ->
-      key = Key.zone_rr(view_name, name, record.owner, record.type)
-
-      value = %{
-        rrset: record.rrset,
-        owner: record.owner,
-        type: record.type,
-        zone: name,
-        class: :in,
-        source: :import,
-        updated_at: now
-      }
-
-      Backend.active().put(key, value, consistency: :strong)
-    end)
-
-    :telemetry.execute(
-      [:yellow_dog, :store, :zone, :imported],
-      %{},
-      %{zone: name, record_count: length(records)}
-    )
-
-    :ok
-  catch
-    {:error, _} = error -> error
   end
 
   @doc """
@@ -579,12 +595,9 @@ defmodule YellowDog.Store.Zone do
 
   # A zone metadata key has the form dns:view:{v}:zone:{name}
   # An RR key has dns:view:{v}:zone:{name}:rr:{owner}:{type}
-  # We distinguish them by checking that after "zone:" there's no further ":"
+  # We distinguish them by checking that the key does NOT contain ":rr:"
   defp zone_metadata_key?(key) do
-    case String.split(key, ":zone:", parts: 2) do
-      [_prefix, suffix] -> not String.contains?(suffix, ":")
-      _ -> false
-    end
+    String.contains?(key, ":zone:") and not String.contains?(key, ":rr:")
   end
 
   # Extract view_name from key: "dns:view:{view_name}:zone:{zone_name}"
@@ -596,7 +609,9 @@ defmodule YellowDog.Store.Zone do
     end
   end
 
-  defp default_soa(name) do
+  @doc "Default SOA record values for a zone."
+  @spec default_soa(zone_name()) :: soa()
+  def default_soa(name) do
     %{
       mname: "ns1.#{name}",
       rname: "admin.#{name}",

--- a/apps/yellow_dog_store/test/yellow_dog/store/key_test.exs
+++ b/apps/yellow_dog_store/test/yellow_dog/store/key_test.exs
@@ -100,14 +100,14 @@ defmodule YellowDog.Store.KeyTest do
 
   describe "zone/1" do
     test "builds correct key" do
-      assert Key.zone("example.com") == "dns:zone:example.com"
+      assert Key.zone("example.com") == "dns:view:default:zone:example.com"
     end
   end
 
   describe "zone_rr/3" do
     test "builds correct key" do
       assert Key.zone_rr("example.com", "www.example.com", :a) ==
-               "dns:zone:example.com:rr:www.example.com:a"
+               "dns:view:default:zone:example.com:rr:www.example.com:a"
     end
   end
 
@@ -164,11 +164,11 @@ defmodule YellowDog.Store.KeyTest do
     end
 
     test "zone_prefix" do
-      assert Key.zone_prefix() == "dns:zone:"
+      assert Key.zone_prefix() == "dns:view:default:zone:"
     end
 
     test "zone_rr_prefix includes zone name" do
-      assert Key.zone_rr_prefix("example.com") == "dns:zone:example.com:rr:"
+      assert Key.zone_rr_prefix("example.com") == "dns:view:default:zone:example.com:rr:"
     end
 
     test "cache_prefix" do

--- a/apps/yellow_dog_store/test/yellow_dog/store/zone_test.exs
+++ b/apps/yellow_dog_store/test/yellow_dog/store/zone_test.exs
@@ -5,6 +5,8 @@ defmodule YellowDog.Store.ZoneTest do
 
   alias YellowDog.Store.Zone
 
+  @view "default"
+
   @test_soa %{
     mname: "ns1.example.com",
     rname: "admin.example.com",
@@ -20,11 +22,16 @@ defmodule YellowDog.Store.ZoneTest do
     :ok
   end
 
-  describe "create_zone/3" do
-    test "creates zone metadata" do
-      assert :ok = Zone.create_zone("test-create.example.com", @test_soa)
+  # -------------------------------------------------------------------
+  # Auth zone metadata
+  # -------------------------------------------------------------------
 
-      assert {:ok, zone} = Zone.get_zone("test-create.example.com")
+  describe "create_zone/4 (auth)" do
+    test "creates zone metadata with zone_type" do
+      assert :ok = Zone.create_zone(@view, "test-create.example.com", @test_soa)
+
+      assert {:ok, zone} = Zone.get_zone(@view, "test-create.example.com")
+      assert zone.zone_type == :auth
       assert zone.origin == "test-create.example.com"
       assert zone.soa.mname == "ns1.example.com"
       assert zone.authoritative == true
@@ -33,14 +40,14 @@ defmodule YellowDog.Store.ZoneTest do
 
     test "create_zone with custom options" do
       assert :ok =
-               Zone.create_zone("test-opts.example.com", @test_soa,
+               Zone.create_zone(@view, "test-opts.example.com", @test_soa,
                  default_ttl: 7200,
                  authoritative: false,
                  allow_dynamic_update: true,
                  serial_strategy: :increment
                )
 
-      assert {:ok, zone} = Zone.get_zone("test-opts.example.com")
+      assert {:ok, zone} = Zone.get_zone(@view, "test-opts.example.com")
       assert zone.default_ttl == 7200
       assert zone.authoritative == false
       assert zone.allow_dynamic_update == true
@@ -48,37 +55,164 @@ defmodule YellowDog.Store.ZoneTest do
     end
 
     test "duplicate zone creation returns error" do
-      Zone.create_zone("test-dup.example.com", @test_soa)
+      Zone.create_zone(@view, "test-dup.example.com", @test_soa)
 
       assert {:error, :already_exists} =
-               Zone.create_zone("test-dup.example.com", @test_soa)
+               Zone.create_zone(@view, "test-dup.example.com", @test_soa)
     end
   end
 
-  describe "delete_zone/1" do
+  describe "delete_zone/2" do
     test "removes zone and all records" do
-      Zone.create_zone("test-del.example.com", @test_soa)
+      Zone.create_zone(@view, "test-del.example.com", @test_soa)
 
-      Zone.put_rrset("test-del.example.com", "www.test-del.example.com", :a, [
+      Zone.put_rrset(@view, "test-del.example.com", "www.test-del.example.com", :a, [
         %{rdata: {192, 168, 1, 1}, ttl: 3600}
       ])
 
-      assert :ok = Zone.delete_zone("test-del.example.com")
-      assert {:error, :not_found} = Zone.get_zone("test-del.example.com")
+      assert :ok = Zone.delete_zone(@view, "test-del.example.com")
+      assert {:error, :not_found} = Zone.get_zone(@view, "test-del.example.com")
 
       assert {:error, :not_found} =
-               Zone.get_rrset("test-del.example.com", "www.test-del.example.com", :a)
+               Zone.get_rrset(@view, "test-del.example.com", "www.test-del.example.com", :a)
     end
   end
 
-  describe "put_rrset/4 and get_rrset/3" do
+  # -------------------------------------------------------------------
+  # Forward zone
+  # -------------------------------------------------------------------
+
+  describe "create_forward_zone/4" do
+    test "creates forward zone with forwarders" do
+      forwarders = [%{ip: "8.8.8.8", port: 53}, %{ip: "8.8.4.4", port: 53}]
+
+      assert :ok =
+               Zone.create_forward_zone(@view, "corp.internal", forwarders,
+                 forward_mode: :first,
+                 timeout_ms: 3000
+               )
+
+      assert {:ok, zone} = Zone.get_zone(@view, "corp.internal")
+      assert zone.zone_type == :forward
+      assert zone.origin == "corp.internal"
+      assert zone.forwarders == forwarders
+      assert zone.forward_mode == :first
+      assert zone.timeout_ms == 3000
+      assert zone.max_retries == 2
+    end
+
+    test "duplicate forward zone returns error" do
+      Zone.create_forward_zone(@view, "dup.internal", [%{ip: "10.0.0.1", port: 53}])
+
+      assert {:error, :already_exists} =
+               Zone.create_forward_zone(@view, "dup.internal", [%{ip: "10.0.0.2", port: 53}])
+    end
+
+    test "defaults forward_mode to :only" do
+      Zone.create_forward_zone(@view, "default-mode.internal", [%{ip: "10.0.0.1", port: 53}])
+
+      assert {:ok, zone} = Zone.get_zone(@view, "default-mode.internal")
+      assert zone.forward_mode == :only
+    end
+  end
+
+  describe "update_forward_zone/3" do
+    test "updates forwarders list" do
+      Zone.create_forward_zone(@view, "upd-fwd.internal", [%{ip: "10.0.0.1", port: 53}])
+
+      new_forwarders = [%{ip: "10.0.0.2", port: 53}, %{ip: "10.0.0.3", port: 53}]
+
+      assert :ok =
+               Zone.update_forward_zone(@view, "upd-fwd.internal", %{forwarders: new_forwarders})
+
+      assert {:ok, zone} = Zone.get_zone(@view, "upd-fwd.internal")
+      assert zone.forwarders == new_forwarders
+    end
+
+    test "updates forward_mode" do
+      Zone.create_forward_zone(@view, "mode-fwd.internal", [%{ip: "10.0.0.1", port: 53}])
+
+      assert :ok = Zone.update_forward_zone(@view, "mode-fwd.internal", %{forward_mode: :first})
+
+      assert {:ok, zone} = Zone.get_zone(@view, "mode-fwd.internal")
+      assert zone.forward_mode == :first
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Stub zone
+  # -------------------------------------------------------------------
+
+  describe "create_stub_zone/4" do
+    test "creates stub zone with primaries" do
+      primaries = [%{ip: "10.2.0.1", port: 53}, %{ip: "10.2.0.2", port: 53}]
+
+      assert :ok =
+               Zone.create_stub_zone(@view, "subsidiary.example.com", primaries,
+                 refresh_interval: 1800
+               )
+
+      assert {:ok, zone} = Zone.get_zone(@view, "subsidiary.example.com")
+      assert zone.zone_type == :stub
+      assert zone.origin == "subsidiary.example.com"
+      assert zone.primaries == primaries
+      assert zone.refresh_interval == 1800
+    end
+
+    test "duplicate stub zone returns error" do
+      Zone.create_stub_zone(@view, "dup-stub.example.com", [%{ip: "10.0.0.1", port: 53}])
+
+      assert {:error, :already_exists} =
+               Zone.create_stub_zone(@view, "dup-stub.example.com", [%{ip: "10.0.0.2", port: 53}])
+    end
+
+    test "defaults refresh_interval to 3600" do
+      Zone.create_stub_zone(@view, "default-stub.example.com", [%{ip: "10.0.0.1", port: 53}])
+
+      assert {:ok, zone} = Zone.get_zone(@view, "default-stub.example.com")
+      assert zone.refresh_interval == 3600
+    end
+  end
+
+  describe "update_stub_zone/3" do
+    test "updates primaries" do
+      Zone.create_stub_zone(@view, "upd-stub.example.com", [%{ip: "10.0.0.1", port: 53}])
+
+      new_primaries = [%{ip: "10.0.0.5", port: 53}]
+
+      assert :ok =
+               Zone.update_stub_zone(@view, "upd-stub.example.com", %{primaries: new_primaries})
+
+      assert {:ok, zone} = Zone.get_zone(@view, "upd-stub.example.com")
+      assert zone.primaries == new_primaries
+    end
+
+    test "updates refresh_interval" do
+      Zone.create_stub_zone(@view, "ri-stub.example.com", [%{ip: "10.0.0.1", port: 53}])
+
+      assert :ok = Zone.update_stub_zone(@view, "ri-stub.example.com", %{refresh_interval: 7200})
+
+      assert {:ok, zone} = Zone.get_zone(@view, "ri-stub.example.com")
+      assert zone.refresh_interval == 7200
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # RRset operations (auth only)
+  # -------------------------------------------------------------------
+
+  describe "put_rrset/5 and get_rrset/4" do
     test "creates and retrieves an RRset" do
-      Zone.create_zone("test-rr.example.com", @test_soa)
+      Zone.create_zone(@view, "test-rr.example.com", @test_soa)
 
       rrset = [%{rdata: {192, 168, 1, 1}, ttl: 300}]
-      assert :ok = Zone.put_rrset("test-rr.example.com", "www.test-rr.example.com", :a, rrset)
 
-      assert {:ok, record} = Zone.get_rrset("test-rr.example.com", "www.test-rr.example.com", :a)
+      assert :ok =
+               Zone.put_rrset(@view, "test-rr.example.com", "www.test-rr.example.com", :a, rrset)
+
+      assert {:ok, record} =
+               Zone.get_rrset(@view, "test-rr.example.com", "www.test-rr.example.com", :a)
+
       assert record.rrset == rrset
       assert record.owner == "www.test-rr.example.com"
       assert record.type == :a
@@ -86,109 +220,180 @@ defmodule YellowDog.Store.ZoneTest do
     end
 
     test "get_rrset returns not_found for missing record" do
-      Zone.create_zone("test-rr2.example.com", @test_soa)
+      Zone.create_zone(@view, "test-rr2.example.com", @test_soa)
 
       assert {:error, :not_found} =
-               Zone.get_rrset("test-rr2.example.com", "nonexistent.test-rr2.example.com", :a)
+               Zone.get_rrset(
+                 @view,
+                 "test-rr2.example.com",
+                 "nonexistent.test-rr2.example.com",
+                 :a
+               )
     end
   end
 
   describe "SOA serial auto-increment" do
     test "serial increments after put_rrset" do
-      Zone.create_zone("test-serial.example.com", @test_soa)
-      {:ok, zone_before} = Zone.get_zone("test-serial.example.com")
+      Zone.create_zone(@view, "test-serial.example.com", @test_soa)
+      {:ok, zone_before} = Zone.get_zone(@view, "test-serial.example.com")
 
-      Zone.put_rrset("test-serial.example.com", "www.test-serial.example.com", :a, [
+      Zone.put_rrset(@view, "test-serial.example.com", "www.test-serial.example.com", :a, [
         %{rdata: {10, 0, 0, 1}, ttl: 300}
       ])
 
-      {:ok, zone_after} = Zone.get_zone("test-serial.example.com")
+      {:ok, zone_after} = Zone.get_zone(@view, "test-serial.example.com")
       assert zone_after.soa.serial > zone_before.soa.serial
     end
 
     test "serial increments after delete_rrset" do
-      Zone.create_zone("test-serial2.example.com", @test_soa)
+      Zone.create_zone(@view, "test-serial2.example.com", @test_soa)
 
-      Zone.put_rrset("test-serial2.example.com", "www.test-serial2.example.com", :a, [
+      Zone.put_rrset(@view, "test-serial2.example.com", "www.test-serial2.example.com", :a, [
         %{rdata: {10, 0, 0, 2}, ttl: 300}
       ])
 
-      {:ok, zone_before} = Zone.get_zone("test-serial2.example.com")
+      {:ok, zone_before} = Zone.get_zone(@view, "test-serial2.example.com")
 
-      Zone.delete_rrset("test-serial2.example.com", "www.test-serial2.example.com", :a)
+      Zone.delete_rrset(@view, "test-serial2.example.com", "www.test-serial2.example.com", :a)
 
-      {:ok, zone_after} = Zone.get_zone("test-serial2.example.com")
+      {:ok, zone_after} = Zone.get_zone(@view, "test-serial2.example.com")
       assert zone_after.soa.serial > zone_before.soa.serial
     end
-  end
 
-  describe "list_records/1" do
-    test "lists all RRsets in a zone" do
-      Zone.create_zone("test-list.example.com", @test_soa)
-
-      Zone.put_rrset("test-list.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
-
-      Zone.put_rrset("test-list.example.com", "mail", :mx, [
-        %{rdata: "mail.test-list.example.com", priority: 10}
-      ])
-
-      assert {:ok, records} = Zone.list_records("test-list.example.com")
-      assert length(records) >= 2
+    test "increment_serial is no-op for non-auth zones" do
+      Zone.create_forward_zone(@view, "fwd-serial.internal", [%{ip: "10.0.0.1", port: 53}])
+      assert :ok = Zone.increment_serial(@view, "fwd-serial.internal")
     end
   end
 
   describe "list_records/2" do
+    test "lists all RRsets in a zone" do
+      Zone.create_zone(@view, "test-list.example.com", @test_soa)
+
+      Zone.put_rrset(@view, "test-list.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
+
+      Zone.put_rrset(@view, "test-list.example.com", "mail", :mx, [
+        %{rdata: "mail.test-list.example.com", priority: 10}
+      ])
+
+      assert {:ok, records} = Zone.list_records(@view, "test-list.example.com")
+      assert length(records) >= 2
+    end
+  end
+
+  describe "list_records/3" do
     test "filters records by owner name" do
-      Zone.create_zone("test-list2.example.com", @test_soa)
+      Zone.create_zone(@view, "test-list2.example.com", @test_soa)
 
-      Zone.put_rrset("test-list2.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
-      Zone.put_rrset("test-list2.example.com", "www", :aaaa, [%{rdata: {0, 0, 0, 0, 0, 0, 0, 1}}])
-      Zone.put_rrset("test-list2.example.com", "mail", :a, [%{rdata: {10, 0, 0, 2}}])
+      Zone.put_rrset(@view, "test-list2.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
 
-      assert {:ok, records} = Zone.list_records("test-list2.example.com", "www")
+      Zone.put_rrset(@view, "test-list2.example.com", "www", :aaaa, [
+        %{rdata: {0, 0, 0, 0, 0, 0, 0, 1}}
+      ])
+
+      Zone.put_rrset(@view, "test-list2.example.com", "mail", :a, [%{rdata: {10, 0, 0, 2}}])
+
+      assert {:ok, records} = Zone.list_records(@view, "test-list2.example.com", "www")
       assert length(records) == 2
       assert Enum.all?(records, fn r -> r.owner == "www" end)
     end
   end
 
-  describe "delete_rrset/3" do
+  describe "delete_rrset/4" do
     test "removes an RRset" do
-      Zone.create_zone("test-delrr.example.com", @test_soa)
+      Zone.create_zone(@view, "test-delrr.example.com", @test_soa)
 
-      Zone.put_rrset("test-delrr.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
-      assert :ok = Zone.delete_rrset("test-delrr.example.com", "www", :a)
-      assert {:error, :not_found} = Zone.get_rrset("test-delrr.example.com", "www", :a)
+      Zone.put_rrset(@view, "test-delrr.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
+      assert :ok = Zone.delete_rrset(@view, "test-delrr.example.com", "www", :a)
+      assert {:error, :not_found} = Zone.get_rrset(@view, "test-delrr.example.com", "www", :a)
     end
   end
+
+  # -------------------------------------------------------------------
+  # Listing (cross-type)
+  # -------------------------------------------------------------------
 
   describe "list_zones/0" do
-    test "returns list of zone names" do
-      Zone.create_zone("test-listzones.example.com", @test_soa)
+    test "returns all zones across all views" do
+      Zone.create_zone(@view, "auth.example.com", @test_soa)
+      Zone.create_forward_zone(@view, "fwd.example.com", [%{ip: "10.0.0.1", port: 53}])
+      Zone.create_stub_zone(@view, "stub.example.com", [%{ip: "10.0.0.2", port: 53}])
 
-      assert {:ok, names} = Zone.list_zones()
-      assert is_list(names)
-      assert "test-listzones.example.com" in names
+      assert {:ok, zones} = Zone.list_zones()
+      assert is_list(zones)
+      origins = Enum.map(zones, & &1.origin)
+      assert "auth.example.com" in origins
+      assert "fwd.example.com" in origins
+      assert "stub.example.com" in origins
     end
   end
 
-  describe "import/2" do
+  describe "list_zones_for_view/1" do
+    test "returns zones only for the specified view" do
+      Zone.create_zone("view-a", "a.example.com", @test_soa)
+      Zone.create_zone("view-b", "b.example.com", @test_soa)
+
+      assert {:ok, zones} = Zone.list_zones_for_view("view-a")
+      origins = Enum.map(zones, & &1.origin)
+      assert "a.example.com" in origins
+      refute "b.example.com" in origins
+    end
+  end
+
+  describe "list_zones_by_type/1" do
+    test "filters by zone type" do
+      Zone.create_zone(@view, "auth-filter.example.com", @test_soa)
+      Zone.create_forward_zone(@view, "fwd-filter.example.com", [%{ip: "10.0.0.1", port: 53}])
+      Zone.create_stub_zone(@view, "stub-filter.example.com", [%{ip: "10.0.0.2", port: 53}])
+
+      assert {:ok, auth_zones} = Zone.list_zones_by_type(:auth)
+      assert Enum.all?(auth_zones, fn z -> z.zone_type == :auth end)
+      assert Enum.any?(auth_zones, fn z -> z.origin == "auth-filter.example.com" end)
+
+      assert {:ok, fwd_zones} = Zone.list_zones_by_type(:forward)
+      assert Enum.all?(fwd_zones, fn z -> z.zone_type == :forward end)
+
+      assert {:ok, stub_zones} = Zone.list_zones_by_type(:stub)
+      assert Enum.all?(stub_zones, fn z -> z.zone_type == :stub end)
+    end
+  end
+
+  describe "delete_zone/2 works for all types" do
+    test "deletes forward zone" do
+      Zone.create_forward_zone(@view, "del-fwd.internal", [%{ip: "10.0.0.1", port: 53}])
+      assert :ok = Zone.delete_zone(@view, "del-fwd.internal")
+      assert {:error, :not_found} = Zone.get_zone(@view, "del-fwd.internal")
+    end
+
+    test "deletes stub zone" do
+      Zone.create_stub_zone(@view, "del-stub.example.com", [%{ip: "10.0.0.1", port: 53}])
+      assert :ok = Zone.delete_zone(@view, "del-stub.example.com")
+      assert {:error, :not_found} = Zone.get_zone(@view, "del-stub.example.com")
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Import / Export
+  # -------------------------------------------------------------------
+
+  describe "import_zone/3" do
     test "imports records into a zone" do
       records = [
         %{owner: "test-import.example.com", type: :soa, rrset: [@test_soa]},
         %{owner: "www.test-import.example.com", type: :a, rrset: [%{rdata: {10, 0, 0, 1}}]}
       ]
 
-      assert :ok = Zone.import("test-import.example.com", records)
-      assert {:ok, _zone} = Zone.get_zone("test-import.example.com")
+      assert :ok = Zone.import_zone(@view, "test-import.example.com", records)
+      assert {:ok, _zone} = Zone.get_zone(@view, "test-import.example.com")
     end
   end
 
-  describe "export/1" do
+  describe "export_zone/2" do
     test "exports all records from a zone" do
-      Zone.create_zone("test-export.example.com", @test_soa)
-      Zone.put_rrset("test-export.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
+      Zone.create_zone(@view, "test-export.example.com", @test_soa)
+      Zone.put_rrset(@view, "test-export.example.com", "www", :a, [%{rdata: {10, 0, 0, 1}}])
 
-      assert {:ok, records} = Zone.export("test-export.example.com")
+      assert {:ok, records} = Zone.export_zone(@view, "test-export.example.com")
       assert is_list(records)
     end
   end
@@ -206,11 +411,10 @@ defmodule YellowDog.Store.ZoneTest do
         }
       ]
 
-      assert :ok = Zone.import("rt.example.com", records)
+      assert :ok = Zone.import_zone(@view, "rt.example.com", records)
 
-      assert {:ok, exported} = Zone.export("rt.example.com")
+      assert {:ok, exported} = Zone.export_zone(@view, "rt.example.com")
 
-      # Verify all non-SOA records round-trip
       for original <- records, original.type != :soa do
         match =
           Enum.find(exported, fn r ->
@@ -223,24 +427,31 @@ defmodule YellowDog.Store.ZoneTest do
     end
   end
 
-  describe "RRset CAS prevents concurrent edit races" do
-    test "concurrent put_rrset on same key serializes correctly" do
-      Zone.create_zone("test-cas.example.com", @test_soa)
+  describe "update_zone/3 (generic)" do
+    test "updates auth zone metadata" do
+      Zone.create_zone(@view, "upd-auth.example.com", @test_soa)
+      assert :ok = Zone.update_zone(@view, "upd-auth.example.com", %{default_ttl: 7200})
 
-      # First write
-      assert :ok =
-               Zone.put_rrset("test-cas.example.com", "www", :a, [
-                 %{rdata: {10, 0, 0, 1}}
-               ])
+      assert {:ok, zone} = Zone.get_zone(@view, "upd-auth.example.com")
+      assert zone.default_ttl == 7200
+    end
+  end
 
-      # Second write (overwrites first)
-      assert :ok =
-               Zone.put_rrset("test-cas.example.com", "www", :a, [
-                 %{rdata: {10, 0, 0, 2}}
-               ])
+  # -------------------------------------------------------------------
+  # View scoping
+  # -------------------------------------------------------------------
 
-      {:ok, record} = Zone.get_rrset("test-cas.example.com", "www", :a)
-      assert [%{rdata: {10, 0, 0, 2}}] = record.rrset
+  describe "view scoping" do
+    test "same zone name in different views are independent" do
+      Zone.create_zone("internal", "example.com", @test_soa)
+
+      Zone.create_forward_zone("external", "example.com", [%{ip: "8.8.8.8", port: 53}])
+
+      assert {:ok, internal} = Zone.get_zone("internal", "example.com")
+      assert internal.zone_type == :auth
+
+      assert {:ok, external} = Zone.get_zone("external", "example.com")
+      assert external.zone_type == :forward
     end
   end
 end

--- a/docs/plans/zone.md
+++ b/docs/plans/zone.md
@@ -1,0 +1,368 @@
+# DNS Zone Support — Store-Backed Implementation Plan
+
+## Context
+
+Yellow Dog already has working Auth, Forward, and Stub zone GenServer processes (`apps/yellow_dog_dns/lib/yellow_dog/dns/zone/{auth,forward,stub}.ex`). However, zone configuration is currently loaded from TOML files (`data/dns/zones.toml` via `ZoneStore`) and auth zone records live in per-process ETS tables. Forward/stub zone configs are passed as opts at start time.
+
+The goal is to make **all zone data and configuration persist in YellowDog.Store** (Concord-backed KV store), eliminating TOML config as the source of truth for zone data. This enables:
+- Runtime zone management via API/UI without config file edits
+- Cluster-wide zone data replication via Concord's Raft consensus
+- EventBridge-driven zone reload on changes
+
+`Store.Zone` (`apps/yellow_dog_store/lib/yellow_dog/store/zone.ex`) already handles auth zone metadata + RRset CRUD. We need to extend it for forward and stub zone types, then wire the zone GenServers to load/save via Store.
+
+---
+
+## Phase 1: Extend Store.Zone for All Zone Types
+
+### 1.1 View-scoped key pattern
+
+Zones are scoped to views (split-horizon DNS). The Store key hierarchy must reflect this:
+
+**Key patterns**:
+- Zone metadata (all types): `dns:view:{view_name}:zone:{zone_name}`
+- Resource records (auth only): `dns:view:{view_name}:zone:{zone_name}:rr:{owner}:{type}`
+
+This matches the `{view_name, zone_type, zone_name}` tuple used in `ZoneRegistry` and `ZoneController`. The same zone name in different views produces different Store keys.
+
+**Important**: Only auth zones have zone data (RRsets). Forward and stub zones store only their configuration metadata — they have no zone data. Forward zones proxy queries upstream. Stub zones cache NS/glue at runtime from querying primaries but don't persist that cache.
+
+### 1.2 Zone metadata schemas per type
+
+Add a `:zone_type` field to discriminate zone types in metadata.
+
+**Auth zone metadata** (existing, add `:zone_type`):
+```elixir
+%{
+  zone_type: :auth,
+  origin: name,
+  soa: %{mname, rname, serial, refresh, retry, expire, minimum},
+  default_ttl: 3600,
+  authoritative: true,
+  allow_dynamic_update: false,
+  serial_strategy: :date_serial,
+  created_at: now,
+  updated_at: now
+}
+```
+Auth zones also store RRsets under `dns:view:{view}:zone:{name}:rr:{owner}:{type}`.
+
+**Forward zone metadata** (new — config only, no zone data):
+```elixir
+%{
+  zone_type: :forward,
+  origin: name,
+  forwarders: [%{ip: "8.8.8.8", port: 53}, ...],
+  forward_mode: :only | :first,   # BIND9: forward only; vs forward first;
+  timeout_ms: 5000,
+  max_retries: 2,
+  created_at: now,
+  updated_at: now
+}
+```
+
+**Stub zone metadata** (new — config only, NS/glue cached at runtime, not persisted):
+```elixir
+%{
+  zone_type: :stub,
+  origin: name,
+  primaries: [%{ip: "10.0.0.1", port: 53}, ...],  # servers to query for NS refresh
+  refresh_interval: 3600,                           # how often to re-query primaries
+  created_at: now,
+  updated_at: now
+}
+```
+Note: `ns_records` and `glue_records` are runtime cache — obtained by querying primaries. They live in GenServer state only, not in Store.
+
+### 1.3 New Store.Zone functions
+
+**File**: `apps/yellow_dog_store/lib/yellow_dog/store/zone.ex`
+
+All functions now take `view_name` as first argument:
+
+```elixir
+# Auth zone — metadata + RRsets (update existing signatures to accept view_name)
+create_zone(view_name, zone_name, soa, opts)
+get_zone(view_name, zone_name)
+delete_zone(view_name, zone_name)          # also deletes all RRsets for auth zones
+put_rrset(view_name, zone_name, owner, type, rrset)
+get_rrset(view_name, zone_name, owner, type)
+delete_rrset(view_name, zone_name, owner, type)
+list_records(view_name, zone_name)
+list_records(view_name, zone_name, owner)
+import_zone(view_name, zone_name, records)
+export_zone(view_name, zone_name)
+increment_serial(view_name, zone_name)
+
+# Forward zone — config only, no zone data
+create_forward_zone(view_name, name, forwarders, opts)  # opts: forward_mode, timeout_ms, max_retries
+update_forward_zone(view_name, name, attrs)             # CAS update
+
+# Stub zone — config only (NS/glue are runtime cache, not persisted)
+create_stub_zone(view_name, name, primaries, opts)      # opts: refresh_interval
+update_stub_zone(view_name, name, attrs)                # CAS update
+
+# Listing (all zone types)
+list_zones()                          # All zones across all views
+list_zones_for_view(view_name)        # All zones in a view
+list_zones_by_type(zone_type)         # Filter by type across all views
+
+# Generic metadata update
+update_zone(view_name, zone_name, attrs)  # CAS update on any zone type
+```
+
+### 1.4 Update Store.Key for view-scoped keys
+
+**File**: `apps/yellow_dog_store/lib/yellow_dog/store/key.ex`
+
+Replace existing zone key functions with view-scoped versions:
+
+```elixir
+# Zone metadata key (view-scoped)
+def zone(view_name, zone_name), do: "dns:view:#{view_name}:zone:#{zone_name}"
+
+# Zone resource record key (view-scoped)
+def zone_rr(view_name, zone_name, owner, type),
+  do: "dns:view:#{view_name}:zone:#{zone_name}:rr:#{owner}:#{type}"
+
+# Prefix scans
+def view_prefix(view_name), do: "dns:view:#{view_name}:"
+def zone_prefix(view_name), do: "dns:view:#{view_name}:zone:"
+def zone_rr_prefix(view_name, zone_name), do: "dns:view:#{view_name}:zone:#{zone_name}:rr:"
+def all_views_prefix, do: "dns:view:"
+```
+
+Deprecate old `zone(name)` and `zone_rr(zone_name, owner, type)` — add `@deprecated` attribute and delegate to new functions with `view_name: "default"`.
+
+### 1.5 Update Store facade delegates
+
+**File**: `apps/yellow_dog_store/lib/yellow_dog/store.ex`
+
+Add delegates for the new `Store.Zone` functions.
+
+---
+
+## Phase 2: Wire Zone GenServers to Store
+
+### 2.1 Auth Zone — Store-backed record persistence
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex`
+
+Currently: Records stored in per-process ETS table. `save/1` writes to zone file.
+
+**Runtime model**: ETS is the single source of truth while the server is running. Store is persistence only — used to survive restarts. No reads from Store during normal operation.
+
+Change:
+- On `init/1`: Load records from `Store.Zone.list_records(view_name, zone_name)` into ETS
+- On `add_record/2` / `remove_record/3`: Write to ETS only (runtime truth). Then async-sync changed RRset to Store for persistence.
+- On `import_zone_file/2`: Import into ETS, then batch-sync all records to Store.
+- On `terminate/2`: Flush all dirty records to Store before shutdown.
+- All query resolution reads ETS only — zero Store reads in hot path.
+- Sync to Store is fire-and-forget (async Task) on mutation, plus a guaranteed flush on graceful stop.
+
+### 2.2 Forward Zone — Store-backed config
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex`
+
+Currently: Config passed as opts at start time. No persistence.
+
+**Runtime model**: GenServer state (upstreams, forward_mode, etc.) is the runtime truth. Store is persistence only.
+
+Change:
+- On `init/1`: Load config from `Store.Zone.get_zone(view_name, name)` into GenServer state
+- On `update_config/2` (new API): Update GenServer state, then async-sync to Store
+- On `reload/2`: Update GenServer state from new config, then async-sync to Store
+- On `terminate/2`: Flush current config to Store
+
+### 2.3 Stub Zone — Store-backed config
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex`
+
+**Runtime model**: GenServer state is runtime truth. Store persists config (primaries, refresh_interval) only. NS records and glue are runtime cache obtained by querying primaries — not persisted.
+
+- On `init/1`: Load config (primaries, refresh_interval) from `Store.Zone.get_zone(view_name, name)`. Then query primaries for NS/glue to populate runtime cache.
+- On `update_config/2` (new API): Update primaries/refresh config in state, async-sync to Store. Re-query primaries for fresh NS/glue.
+- On `reload/2`: Same as update_config
+- On `terminate/2`: Flush config (primaries, refresh_interval) to Store. NS/glue cache is discarded — will be re-fetched on next start.
+
+### 2.4 ZoneController — Create zone in Store before starting process
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex`
+
+Update `start_zone/4` to:
+1. Persist zone metadata to Store (if not already exists)
+2. Start the GenServer process
+
+Update startup flow to:
+1. On DNS supervisor start, scan `Store.Zone.list_zones()` (returns all view-scoped zones)
+2. For each zone in Store, start the corresponding GenServer via ZoneController with its view_name
+
+### 2.5 ZoneReloader — Handle all zone types
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_reloader.ex`
+
+Update subscription pattern from `dns:zone:*` to `dns:view:*` to match new key hierarchy. Needs to handle:
+- Forward zone metadata changes → reload forwarders
+- Stub zone metadata changes → reload NS/glue records
+- Auth zone RR changes → reload records into ETS (already partially done)
+
+---
+
+## Phase 3: Deprecate TOML-based ZoneStore
+
+### 3.1 Migration path
+
+**File**: `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_store.ex`
+
+- Add `migrate_to_store/0` function that reads TOML zones and writes them to YellowDog.Store
+- Keep `ZoneStore` module for backward compat but mark as deprecated
+- On startup: if Store has zones, use Store; if Store is empty and TOML has zones, auto-migrate
+
+### 3.2 Remove zone config from TOML config
+
+Zone definitions should no longer be in `yellowdogdns_default_config.toml`. The TOML config retains only server-level settings (listen address, port, recursion settings, etc.).
+
+---
+
+## Phase 4: Unit Tests
+
+### 4.1 Store.Zone unit tests
+
+**File**: `apps/yellow_dog_store/test/yellow_dog/store/zone_test.exs`
+
+Test each Store.Zone function in isolation:
+
+**Auth zone tests:**
+- `create_zone/3` — creates metadata, CAS prevents duplicate
+- `delete_zone/1` — removes metadata + all RRsets
+- `get_zone/1` — retrieves metadata
+- `list_zones/0` — lists all zone names
+- `put_rrset/4` — creates/updates RRset, auto-increments serial
+- `get_rrset/3` — retrieves specific RRset
+- `delete_rrset/3` — removes RRset, auto-increments serial
+- `list_records/1` — lists all RRsets in zone
+- `list_records/2` — filters by owner
+- `import/2` — bulk import records
+- `export/1` — export all records
+- `increment_serial/1` — serial strategies (date_serial, increment)
+
+**Forward zone tests:**
+- `create_forward_zone/3` — creates with forwarders + mode
+- `create_forward_zone/3` duplicate — returns `{:error, :already_exists}`
+- `update_forward_zone/2` — updates forwarders list
+- `update_forward_zone/2` — updates forward_mode (:only ↔ :first)
+- `get_zone/1` — returns forward zone metadata with correct zone_type
+- `list_zones_by_type(:forward)` — filters correctly
+
+**Stub zone tests:**
+- `create_stub_zone/3` — creates with primaries + refresh_interval
+- `create_stub_zone/3` duplicate — returns `{:error, :already_exists}`
+- `update_stub_zone/2` — updates primaries
+- `update_stub_zone/2` — updates refresh_interval
+- `get_zone/1` — returns stub zone metadata with correct zone_type (no NS/glue — those are runtime cache)
+- `list_zones_by_type(:stub)` — filters correctly
+
+**Cross-type tests:**
+- `list_zones/0` — returns all zone types
+- `list_zones_by_type/1` — filters by each type
+- `delete_zone/1` — works for all zone types
+
+### 4.2 Zone GenServer unit tests (Store integration)
+
+**Auth zone**: `apps/yellow_dog_dns/test/yellow_dog/dns/zone/auth_test.exs`
+- Add tests for Store-backed persistence: add record → restart process → records still available
+- Test that `add_record` writes to both ETS and Store
+
+**Forward zone**: `apps/yellow_dog_dns/test/yellow_dog/dns/zone/forward_test.exs`
+- Test loading config from Store on init
+- Test `update_config/2` persists to Store
+- Test reload reads from Store
+
+**Stub zone**: `apps/yellow_dog_dns/test/yellow_dog/dns/zone/stub_test.exs`
+- Test loading config from Store on init
+- Test `update_config/2` persists to Store
+- Test reload reads from Store
+
+---
+
+## Phase 5: E2E Tests
+
+E2E tests live in `e2e_test/` at umbrella root and run via `mix test.e2e.dns`.
+
+### 5.1 Auth zone E2E — `e2e_test/dns_zone_auth_e2e_test.exs`
+
+Update existing test to verify Store persistence:
+- Create auth zone via ZoneController → verify zone metadata in Store
+- Add records → query via DNS → verify answers
+- Add records → verify RRsets in Store
+- Restart zone process → verify records survive (loaded from Store)
+- Delete zone → verify Store cleanup
+
+### 5.2 Forward zone E2E — `e2e_test/dns_zone_forward_e2e_test.exs`
+
+Update existing test to verify Store persistence:
+- Create forward zone → verify metadata persisted in Store
+- Query domain → verify forwarding to upstream works
+- Update forwarders via Store → verify zone reloads
+- Test forward-only mode: upstream fails → SERVFAIL
+- Test forward-first mode: upstream fails → fallback (if recursion enabled)
+
+### 5.3 Stub zone E2E — `e2e_test/dns_zone_stub_e2e_test.exs`
+
+Update existing test to verify Store persistence:
+- Create stub zone → verify metadata persisted in Store
+- Verify NS records maintained
+- Verify delegation queries route correctly
+- Update NS records via Store → verify zone reloads
+
+### 5.4 Add mix aliases for zone-specific E2E
+
+**File**: `mix.exs`
+
+```elixir
+"test.e2e.zone.auth": &run_e2e_zone_auth/1,
+"test.e2e.zone.forward": &run_e2e_zone_forward/1,
+"test.e2e.zone.stub": &run_e2e_zone_stub/1,
+```
+
+---
+
+## Critical Files
+
+| File | Action |
+|------|--------|
+| `apps/yellow_dog_store/lib/yellow_dog/store/zone.ex` | Extend for forward/stub zone types |
+| `apps/yellow_dog_store/lib/yellow_dog/store.ex` | Add delegates for new functions |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/auth.ex` | Wire to Store for record persistence |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/forward.ex` | Wire to Store for config persistence |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone/stub.ex` | Wire to Store for config persistence |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_controller.ex` | Store-first zone lifecycle |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_reloader.ex` | Handle all zone type events |
+| `apps/yellow_dog_dns/lib/yellow_dog/dns/zone_store.ex` | Deprecate, add migration |
+| `apps/yellow_dog_store/test/yellow_dog/store/zone_test.exs` | Unit tests for Store.Zone |
+| `apps/yellow_dog_dns/test/yellow_dog/dns/zone/auth_test.exs` | Store integration tests |
+| `apps/yellow_dog_dns/test/yellow_dog/dns/zone/forward_test.exs` | Store integration tests |
+| `apps/yellow_dog_dns/test/yellow_dog/dns/zone/stub_test.exs` | Store integration tests |
+| `e2e_test/dns_zone_auth_e2e_test.exs` | Store persistence E2E |
+| `e2e_test/dns_zone_forward_e2e_test.exs` | Store persistence E2E |
+| `e2e_test/dns_zone_stub_e2e_test.exs` | Store persistence E2E |
+| `mix.exs` | Add zone-specific E2E aliases |
+
+## Verification
+
+1. **Unit tests**: `cd apps/yellow_dog_store && mix test test/yellow_dog/store/zone_test.exs`
+2. **DNS unit tests**: `cd apps/yellow_dog_dns && mix test`
+3. **E2E auth**: `mix test.e2e.zone.auth`
+4. **E2E forward**: `mix test.e2e.zone.forward`
+5. **E2E stub**: `mix test.e2e.zone.stub`
+6. **Full CI check**: `mix compile --warnings-as-errors && mix format --check-formatted && mix credo --strict`
+7. **Manual**: Start dev server, create zones via console UI, restart, verify zones survive
+
+## Implementation Order
+
+1. Phase 1 (Store.Zone extension) — no breaking changes, additive only
+2. Phase 4.1 (Store.Zone unit tests) — validate the new Store functions
+3. Phase 2 (Wire GenServers) — integrate Store with zone processes
+4. Phase 4.2 (GenServer unit tests) — validate the integration
+5. Phase 3 (Deprecate TOML ZoneStore) — migration path
+6. Phase 5 (E2E tests) — full-stack validation

--- a/docs/prd/dns-zone.md
+++ b/docs/prd/dns-zone.md
@@ -1,0 +1,314 @@
+# Product: Store-Backed DNS Zone Management
+
+## Overview
+
+Persist all DNS zone configuration and data in YellowDog.Store (Concord-backed KV store), replacing TOML files as the source of truth for zone definitions. Covers three zone types: authoritative, forward, and stub. ETS remains the runtime data plane for query resolution — Store is persistence only.
+
+**This delivers runtime zone management without config edits or restarts, with cluster-wide replication via Raft consensus.**
+
+## Architecture Reference
+
+The implementation plan is in `docs/plans/zone.md`. All Store key patterns, phase ordering, and file-level changes are defined there. This PRD defines the product requirements and data models.
+
+## Context
+
+Yellow Dog is an Elixir umbrella providing DNS, DHCP, mDNS, and network infrastructure services. The following sibling apps are involved:
+
+- `yellow_dog_dns` — DNS server: views, zones, name resolution, ACLs
+- `yellow_dog_store` — Unified Store facade over Concord (distributed KV)
+- `yellow_dog` — Core config (TOML), orchestration, service manager
+- `ex_dns` — DNS protocol library (messages, zones, records)
+
+## Tech Stack
+
+- **Language**: Elixir 1.18 / OTP 27-28
+- **Storage**: YellowDog.Store (Concord Raft KV, ETS backend for single-node)
+- **Runtime cache**: ETS (per-process, sub-microsecond reads)
+- **Events**: Store.EventBridge (pattern-matched subscriptions)
+- **Test**: ExUnit, E2E with auto-selected ports
+
+## Problem Statement
+
+DNS zone configuration is currently loaded from TOML files (`data/dns/zones.toml` via `ZoneStore`) and auth zone records live in per-process ETS tables with no durable persistence. Forward and stub zone configs are passed as start-time options with no runtime management.
+
+- **No runtime zone management** — adding/removing zones requires editing TOML config files and restarting
+- **No cluster replication** — zone config is local to each node
+- **Data loss on restart** — auth zone records in ETS are lost when the process stops
+- **No unified API** — different zone types have different configuration mechanisms
+
+## Goals
+
+1. All zone configuration and data persists in YellowDog.Store
+2. Zones are manageable at runtime via API without config file edits or restarts
+3. Zone data replicates across cluster nodes via Concord's Raft consensus
+4. EventBridge-driven zone reload on changes (no polling, no restarts)
+5. ETS remains the runtime data plane — zero Store reads in the DNS query hot path
+
+## Non-Goals
+
+- DNSSEC signing or key management
+- Zone transfer protocol (AXFR/IXFR) serving to external secondaries
+- Dynamic DNS update protocol (RFC 2136) from external clients
+- Console UI changes (separate PRD)
+
+## Features
+
+### 1. View-Scoped Zone Storage
+
+All zones are scoped to a DNS view (split-horizon DNS). The Store key hierarchy reflects this:
+
+```
+dns:view:{view_name}:zone:{zone_name}
+dns:view:{view_name}:zone:{zone_name}:rr:{owner}:{type}   # auth only
+```
+
+- Same zone name in different views → different Store keys
+- Matches existing `{view_name, zone_type, zone_name}` tuple in `ZoneRegistry`
+- Prefix scan `dns:view:{view_name}:zone:` returns all zones in a view
+- Prefix scan `dns:view:` returns all zones across all views
+
+### 2. Authoritative Zone (Auth)
+
+An auth zone holds the complete, definitive set of resource records for a domain. The server returns answers with the AA (Authoritative Answer) flag set.
+
+**Persisted in Store:**
+- Zone metadata (SOA, TTL, serial strategy, flags)
+- All resource records (A, AAAA, CNAME, MX, NS, TXT, SRV, PTR, CAA, etc.)
+
+**Runtime model:**
+- ETS is the single source of truth while the server is running
+- Store is persistence only — loaded on start, synced on mutation and stop
+- Query resolution reads ETS only — zero Store reads in hot path
+- Async sync to Store on each mutation; guaranteed flush on graceful shutdown
+
+**Zone metadata:**
+
+```elixir
+%{
+  zone_type: :auth,
+  origin: "example.com",
+  soa: %{mname: "ns1.example.com", rname: "admin.example.com",
+         serial: 2026032401, refresh: 3600, retry: 900, expire: 604800, minimum: 300},
+  default_ttl: 3600,
+  authoritative: true,
+  allow_dynamic_update: false,
+  serial_strategy: :date_serial,
+  created_at: ~U[2026-03-24 00:00:00Z],
+  updated_at: ~U[2026-03-24 00:00:00Z]
+}
+```
+
+**RRset value:**
+
+```elixir
+%{
+  rrset: [%{address: {93, 184, 216, 34}}],
+  owner: "www",
+  type: :a,
+  zone: "example.com",
+  class: :in,
+  source: :api,
+  updated_at: ~U[2026-03-24 00:00:00Z]
+}
+```
+
+**SOA serial management:**
+- Auto-incremented on every RR change
+- Strategies: `:date_serial` (YYYYMMDDNN, 100 changes/day) or `:increment` (simple +1)
+- CAS with bounded retries (max 10) to prevent lost updates
+
+### 3. Forward Zone
+
+A forward zone holds no zone data. It redirects queries for a specific domain to designated upstream forwarders. This is conditional forwarding — different domains can use different upstream servers.
+
+**Persisted in Store:**
+- Configuration only (forwarders list, forward mode, timeout, retries)
+- **No zone data, no RRsets**
+
+**Runtime model:**
+- GenServer state is runtime truth (upstream list, round-robin index, pending queries)
+- Store persists config only — loaded on start, synced on config change and stop
+
+**Zone metadata:**
+
+```elixir
+%{
+  zone_type: :forward,
+  origin: "internal.corp.com",
+  forwarders: [%{ip: "10.1.1.53", port: 53}, %{ip: "10.1.2.53", port: 53}],
+  forward_mode: :only,       # :only = SERVFAIL if all forwarders fail
+                              # :first = fall back to recursion if forwarders fail
+  timeout_ms: 5000,
+  max_retries: 2,
+  created_at: ~U[2026-03-24 00:00:00Z],
+  updated_at: ~U[2026-03-24 00:00:00Z]
+}
+```
+
+**Behavior:**
+- `forward :only` — try forwarders in order; SERVFAIL if all fail (BIND9: `forward only`)
+- `forward :first` — try forwarders first; fall back to normal recursion if all fail (BIND9: `forward first`)
+- Longest-matching zone name wins (most specific forward zone)
+
+**Use cases:**
+- Split-horizon DNS (forward `corp.internal` to internal DNS)
+- Conditional forwarding to partner/cloud DNS
+- Active Directory integration (forward AD zones to domain controllers)
+
+### 4. Stub Zone
+
+A stub zone maintains only the NS records and glue (A/AAAA for those nameservers) for a zone. It does NOT hold full zone data. The purpose is delegation awareness — the resolver knows which nameservers are authoritative without holding all records.
+
+**Persisted in Store:**
+- Configuration only (list of primaries to query, refresh interval)
+
+**NOT persisted (runtime cache only):**
+- NS records and glue A/AAAA records — fetched by querying primaries at runtime
+
+**Runtime model:**
+- GenServer state holds config + cached NS/glue
+- On start: load config from Store, then query primaries for NS/glue
+- Periodic refresh: re-query primaries at `refresh_interval` for fresh NS/glue
+- NS/glue cache discarded on stop — re-fetched on next start
+
+**Zone metadata:**
+
+```elixir
+%{
+  zone_type: :stub,
+  origin: "subsidiary.example.com",
+  primaries: [%{ip: "10.2.0.1", port: 53}, %{ip: "10.2.0.2", port: 53}],
+  refresh_interval: 3600,
+  created_at: ~U[2026-03-24 00:00:00Z],
+  updated_at: ~U[2026-03-24 00:00:00Z]
+}
+```
+
+**Refresh mechanism (NOT zone transfer — uses normal DNS queries):**
+1. Query primary for current SOA → compare serial
+2. If serial changed, query for NS records at zone apex
+3. For each in-bailiwick NS, query for A/AAAA glue
+4. Update runtime cache
+
+**Use cases:**
+- Internal delegation tracking (auto-track child zone NS changes)
+- Multi-site networks (HQ knows branch DNS without replicating branch data)
+- Reduces manual configuration vs maintaining forward zones
+
+### 5. Store.Zone API
+
+```elixir
+# Auth zone — metadata + RRsets
+create_zone(view_name, zone_name, soa, opts)
+get_zone(view_name, zone_name)
+delete_zone(view_name, zone_name)          # also deletes all RRsets
+put_rrset(view_name, zone_name, owner, type, rrset)
+get_rrset(view_name, zone_name, owner, type)
+delete_rrset(view_name, zone_name, owner, type)
+list_records(view_name, zone_name)
+list_records(view_name, zone_name, owner)
+import_zone(view_name, zone_name, records)
+export_zone(view_name, zone_name)
+increment_serial(view_name, zone_name)
+
+# Forward zone — config only
+create_forward_zone(view_name, name, forwarders, opts)
+update_forward_zone(view_name, name, attrs)
+
+# Stub zone — config only
+create_stub_zone(view_name, name, primaries, opts)
+update_stub_zone(view_name, name, attrs)
+
+# Listing
+list_zones()                          # all zones across all views
+list_zones_for_view(view_name)        # all zones in a view
+list_zones_by_type(zone_type)         # filter by type across all views
+
+# Generic
+update_zone(view_name, zone_name, attrs)
+```
+
+### 6. Zone GenServer APIs
+
+Each zone type exposes the existing `Zone.Behaviour` interface plus new Store-backed operations:
+
+- `resolve/2` — resolve a DNS query (reads ETS/state only, never Store)
+- `reload/2` — reload config/data from new opts
+- `update_config/2` — **(new)** update config at runtime, async-sync to Store
+- `stats/1` — return zone statistics
+
+### 7. Zone Lifecycle Management
+
+**ZoneController** orchestrates zone creation and startup:
+1. Persist zone metadata to Store (CAS, prevent duplicate)
+2. Start the zone GenServer process
+3. GenServer loads data from Store on `init/1`
+
+**Startup flow:**
+1. DNS supervisor starts → scan `Store.Zone.list_zones()`
+2. For each zone in Store → start GenServer via ZoneController with its `view_name`
+3. Each GenServer loads its data from Store into ETS/state
+
+**ZoneReloader** subscribes to `dns:view:*` via EventBridge:
+- Auth zone RR changes → reload records into ETS
+- Forward zone metadata changes → reload forwarders in GenServer state
+- Stub zone metadata changes → reload config and re-query primaries
+
+### 8. TOML Migration
+
+- On startup: if Store has zones, use Store; if Store is empty and TOML has zones, auto-migrate
+- `migrate_to_store/0` reads TOML zones and writes to Store (one-time)
+- Old `ZoneStore` module kept but marked `@deprecated`
+- TOML config retains server-level settings only (listen address, port, recursion)
+
+## Testing Requirements
+
+### Unit Tests
+
+**Store.Zone** (`apps/yellow_dog_store/test/yellow_dog/store/zone_test.exs`):
+- CRUD for each zone type (create, get, update, delete)
+- CAS prevents duplicate zone creation
+- Auth zone: RRset CRUD with auto serial increment
+- Auth zone: import/export round-trip
+- Cross-type: list_zones returns all types, list_zones_by_type filters correctly
+- Delete auth zone cascades to all RRsets
+
+**Zone GenServers** (existing test files):
+- Auth: add record → restart process → records survive (loaded from Store)
+- Forward: load config from Store on init; update_config persists to Store
+- Stub: load config from Store on init; update_config persists to Store
+
+### E2E Tests
+
+Each zone type gets a separate E2E test file:
+
+| Test | File | Mix Alias |
+|------|------|-----------|
+| Auth zone | `e2e_test/dns_zone_auth_e2e_test.exs` | `mix test.e2e.zone.auth` |
+| Forward zone | `e2e_test/dns_zone_forward_e2e_test.exs` | `mix test.e2e.zone.forward` |
+| Stub zone | `e2e_test/dns_zone_stub_e2e_test.exs` | `mix test.e2e.zone.stub` |
+
+**Auth E2E:** Create zone → add records → query via DNS → verify answers → restart process → verify records survive → delete zone → verify cleanup
+
+**Forward E2E:** Create forward zone → query domain → verify forwarding → update forwarders → verify reload → test forward-only SERVFAIL → test forward-first fallback
+
+**Stub E2E:** Create stub zone → verify NS records cached → verify delegation routing → update primaries → verify reload
+
+## RFC References
+
+| RFC | Relevance |
+|-----|-----------|
+| RFC 1035 | Zone file format, record types, wire protocol |
+| RFC 1982 | Serial number arithmetic (comparison with wraparound) |
+| RFC 2181 | Authoritative data definition, TTL rules |
+| RFC 2308 | Negative caching (SOA minimum = negative TTL) |
+
+## Success Criteria
+
+1. All zone types can be created, updated, and deleted at runtime without restart
+2. Auth zone records survive process/node restart (loaded from Store)
+3. Forward/stub zone configs survive restart (loaded from Store)
+4. Zero Store reads in DNS query hot path (ETS/state only)
+5. Zone changes propagate across cluster nodes via EventBridge
+6. All unit tests pass; all E2E tests pass
+7. `mix compile --warnings-as-errors && mix format --check-formatted && mix credo --strict` clean

--- a/mix.exs
+++ b/mix.exs
@@ -120,7 +120,10 @@ defmodule YellowDog.Umbrella.MixProject do
       "test.e2e.mdns": &run_e2e_mdns/1,
       "test.e2e.dhcpv4": &run_e2e_dhcpv4/1,
       "test.e2e.dhcpv6": &run_e2e_dhcpv6/1,
-      "test.e2e.netboot": &run_e2e_netboot/1
+      "test.e2e.netboot": &run_e2e_netboot/1,
+      "test.e2e.zone.auth": &run_e2e_zone_auth/1,
+      "test.e2e.zone.forward": &run_e2e_zone_forward/1,
+      "test.e2e.zone.stub": &run_e2e_zone_stub/1
     ]
   end
 
@@ -148,6 +151,18 @@ defmodule YellowDog.Umbrella.MixProject do
 
   defp run_e2e_netboot(_args) do
     run_e2e_test_files(["e2e_test/netboot_tftp_e2e_test.exs"])
+  end
+
+  defp run_e2e_zone_auth(_args) do
+    run_e2e_test_files(["e2e_test/dns_zone_auth_e2e_test.exs"])
+  end
+
+  defp run_e2e_zone_forward(_args) do
+    run_e2e_test_files(["e2e_test/dns_zone_forward_e2e_test.exs"])
+  end
+
+  defp run_e2e_zone_stub(_args) do
+    run_e2e_test_files(["e2e_test/dns_zone_stub_e2e_test.exs"])
   end
 
   defp run_e2e_test_files(paths) do


### PR DESCRIPTION
## Summary
- Add `ZoneController` for Store-first zone lifecycle management (create, update, delete zones via `Store.Zone`)
- Wire all zone GenServers (Auth, Forward, Stub, Cache, Root, RPZ) to persist/load state from Store
- Add view-scoped `Store.Zone` API with key format `zone:{view}:{type}:{name}` for all zone types
- Add `ZoneReloader` improvements for TOML-to-Store migration
- Add comprehensive Store integration tests and zone Store unit tests
- Update `Store.Key` to use view-scoped format, deprecate old functions

## Test plan
- [x] Store integration tests (`store_integration_test.exs`) cover CRUD, RRset sync, concurrent access
- [x] Zone Store unit tests updated for view-scoped key format
- [x] Key tests updated for new format
- [ ] Run full E2E DNS test suite (`mix test.e2e.dns`)
- [ ] Verify zone persistence survives restart