### PR TITLE
feat(tasks): sync cloud DNS zones on schedule

### DIFF
--- a/apps/yellow_dog_console/lib/yellow_dog/console/live/dns_live/zone_live/index.ex
+++ b/apps/yellow_dog_console/lib/yellow_dog/console/live/dns_live/zone_live/index.ex
@@ -14,11 +14,11 @@ defmodule YellowDog.Console.DnsLive.ZoneLive.Index do
 
   alias YellowDog.Console.StringHelper
   alias YellowDog.Console.Validators
-  alias YellowDog.Dns.CloudDnsSyncJob
   alias YellowDog.Dns.ConfigPersistence
   alias YellowDog.Dns.View
   alias YellowDog.Dns.ViewManager
   alias YellowDog.Dns.ZoneController
+  alias YellowDog.Tasks
   alias YellowDog.Store.Provider, as: StoreProvider
   alias YellowDog.Store.Zone, as: StoreZone
 
@@ -704,8 +704,10 @@ defmodule YellowDog.Console.DnsLive.ZoneLive.Index do
 
   defp maybe_enqueue_cloud_dns_sync(view_name, zone_name, :auth, config) do
     if cloud_mirror_config_enabled?(Keyword.get(config, :cloud_mirror)) do
-      case CloudDnsSyncJob.enqueue(view_name, zone_name) do
-        :ok ->
+      task_key = Tasks.cloud_zone_task_key(view_name, zone_name)
+
+      case Tasks.enqueue(task_key) do
+        {:ok, _job} ->
           :ok
 
         {:error, reason} ->

--- a/apps/yellow_dog_console/lib/yellow_dog/console/live/tasks_live/index.ex
+++ b/apps/yellow_dog_console/lib/yellow_dog/console/live/tasks_live/index.ex
@@ -56,7 +56,35 @@ defmodule YellowDog.Console.TasksLive.Index do
                       <div class="text-xs text-on-surface-variant font-mono">{task.key}</div>
                     </td>
                     <td><.status_badge status={task.status} enabled?={task.enabled?} /></td>
-                    <td class="font-mono text-sm">{task.cron || "Manual only"}</td>
+                    <td>
+                      <form
+                        phx-submit="save_task_config"
+                        data-task-key={task.key}
+                        class="flex flex-wrap items-center gap-2"
+                      >
+                        <input type="hidden" name="task_key" value={task.key} />
+                        <input type="hidden" name="task[enabled]" value="false" />
+                        <label class="flex items-center gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            name="task[enabled]"
+                            value="true"
+                            checked={task.enabled?}
+                            class="toggle toggle-sm"
+                          /> Enabled
+                        </label>
+                        <input
+                          type="text"
+                          name="task[cron]"
+                          value={task.cron || ""}
+                          class="input input-sm input-bordered font-mono w-40"
+                          aria-label={"Schedule for #{task.label}"}
+                        />
+                        <button type="submit" class="btn btn-ghost btn-sm">
+                          <.dm_mdi name="content-save" class="h-4 w-4" /> Save
+                        </button>
+                      </form>
+                    </td>
                     <td>{task.source}</td>
                     <td>
                       <div class="flex justify-end gap-2">
@@ -67,7 +95,7 @@ defmodule YellowDog.Console.TasksLive.Index do
                         >
                           <.dm_mdi name="play" class="h-4 w-4" /> Run Now
                         </button>
-                        <.link navigate={"/system/tasks/#{task.key}"} class="btn btn-ghost btn-sm">
+                        <.link navigate={task_path(task.key)} class="btn btn-ghost btn-sm">
                           <.dm_mdi name="history" class="h-4 w-4" /> View History
                         </.link>
                       </div>
@@ -103,6 +131,19 @@ defmodule YellowDog.Console.TasksLive.Index do
     end
   end
 
+  def handle_event("save_task_config", %{"task_key" => key, "task" => task_params}, socket) do
+    case Tasks.update_task(key, task_params) do
+      {:ok, _task} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Task schedule updated")
+         |> assign(:tasks, Tasks.list_tasks())}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Unable to update task: #{inspect(reason)}")}
+    end
+  end
+
   defp status_badge(assigns) do
     ~H"""
     <span class={["badge badge-sm", status_class(@status)]}>
@@ -122,4 +163,9 @@ defmodule YellowDog.Console.TasksLive.Index do
   defp status_label(:failed), do: "Failed"
   defp status_label(:unavailable), do: "Unavailable"
   defp status_label(_status), do: "Idle"
+
+  defp task_path(task_key) do
+    encoded = task_key |> to_string() |> URI.encode(&URI.char_unreserved?/1)
+    "/system/tasks/#{encoded}"
+  end
 end

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/dns_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/dns_live_test.exs
@@ -10,6 +10,7 @@ defmodule YellowDog.Console.DnsLiveTest do
   alias YellowDog.Store.Backend.Ets, as: EtsBackend
   alias YellowDog.Store.Provider
   alias YellowDog.Store.Zone, as: StoreZone
+  alias YellowDog.Tasks
 
   # ============================================================================
   # DNS Overview Page
@@ -841,6 +842,9 @@ defmodule YellowDog.Console.DnsLiveTest do
 
       assert is_binary(result) or match?({:error, {:live_redirect, _}}, result)
       assert_receive {:cloud_dns_sync_enqueued, "default", ^zone_name, []}
+
+      assert [%{state: "completed"} | _] =
+               Tasks.recent_jobs(Tasks.cloud_zone_task_key("default", zone_name))
     end
 
     test "create zone form submits forward zone with upstreams", %{conn: conn} do
@@ -2486,20 +2490,27 @@ defmodule YellowDog.Console.DnsLiveTest do
   end
 
   defp setup_cloud_dns_sync_runner do
-    previous_runner = Application.get_env(:yellow_dog_dns, :cloud_dns_sync_job_runner)
+    previous_sync_fun = Application.get_env(:yellow_dog_tasks, :cloud_zone_sync_fun)
+    previous_task_backend = Application.get_env(:yellow_dog_tasks, :store_backend)
     test_pid = self()
 
-    Application.put_env(:yellow_dog_dns, :cloud_dns_sync_job_runner, fn view_name,
-                                                                        zone_name,
-                                                                        opts ->
+    Application.put_env(:yellow_dog_tasks, :store_backend, EtsBackend)
+    YellowDog.Tasks.Store.clear_all()
+
+    Application.put_env(:yellow_dog_tasks, :cloud_zone_sync_fun, fn view_name, zone_name, opts ->
       send(test_pid, {:cloud_dns_sync_enqueued, view_name, zone_name, opts})
-      :ok
+      {:ok, %{records_synced: 0}}
     end)
 
     on_exit(fn ->
-      case previous_runner do
-        nil -> Application.delete_env(:yellow_dog_dns, :cloud_dns_sync_job_runner)
-        runner -> Application.put_env(:yellow_dog_dns, :cloud_dns_sync_job_runner, runner)
+      case previous_sync_fun do
+        nil -> Application.delete_env(:yellow_dog_tasks, :cloud_zone_sync_fun)
+        sync_fun -> Application.put_env(:yellow_dog_tasks, :cloud_zone_sync_fun, sync_fun)
+      end
+
+      case previous_task_backend do
+        nil -> Application.delete_env(:yellow_dog_tasks, :store_backend)
+        backend -> Application.put_env(:yellow_dog_tasks, :store_backend, backend)
       end
     end)
 

--- a/apps/yellow_dog_console/test/yellow_dog/console/live/tasks_live_test.exs
+++ b/apps/yellow_dog_console/test/yellow_dog/console/live/tasks_live_test.exs
@@ -5,6 +5,7 @@ defmodule YellowDog.Console.TasksLiveTest do
 
   alias YellowDog.Store.Backend
   alias YellowDog.Store.Backend.Ets, as: EtsBackend
+  alias YellowDog.Store.Zone
   alias YellowDog.Tasks
   alias YellowDog.Tasks.Store
 
@@ -20,6 +21,7 @@ defmodule YellowDog.Console.TasksLiveTest do
 
   setup do
     EtsBackend.create_table()
+    :ets.delete_all_objects(EtsBackend.table())
     Backend.set_active(EtsBackend)
 
     previous =
@@ -30,10 +32,15 @@ defmodule YellowDog.Console.TasksLiveTest do
         :mac_database_ensure_started,
         :mac_database_downloader,
         :mac_database_info,
+        :tasks_config,
+        :config_file_path,
+        :cloud_zone_sync_fun,
         :store_backend
       ])
 
     Application.put_env(:yellow_dog_tasks, :store_backend, EtsBackend)
+    Application.delete_env(:yellow_dog_tasks, :tasks_config)
+    Application.delete_env(:yellow_dog_tasks, :config_file_path)
     Store.clear_all()
 
     Application.put_env(:yellow_dog_tasks, :ip_database_downloader, fn
@@ -69,6 +76,42 @@ defmodule YellowDog.Console.TasksLiveTest do
     assert html =~ "Data Sync Tasks"
     assert has_element?(view, "button[phx-click='run_now'][phx-value-task='ip_city']", "Run Now")
     assert has_element?(view, "a[href='/system/tasks/ip_city']", "View History")
+  end
+
+  test "renders cloud zone sync tasks and updates schedule settings", %{conn: conn} do
+    zone_name = "console-cloud-#{System.unique_integer([:positive])}.example.com"
+    create_cloud_zone("default", zone_name, :cloudflare)
+    key = "cloud_zone:default:#{zone_name}"
+
+    {:ok, view, html} = live(conn, ~p"/system/tasks")
+
+    assert html =~ "Cloud DNS: #{zone_name}"
+    assert html =~ "Cloudflare DNS"
+    assert html =~ "0 * * * *"
+    assert has_element?(view, "form[phx-submit='save_task_config'][data-task-key='#{key}']")
+
+    assert has_element?(
+             view,
+             "a[href='/system/tasks/#{URI.encode(key, &URI.char_unreserved?/1)}']",
+             "View History"
+           )
+
+    html =
+      render_submit(view, "save_task_config", %{
+        "task_key" => key,
+        "task" => %{"enabled" => "false", "cron" => "10 * * * *"}
+      })
+
+    assert html =~ "Task schedule updated"
+    assert html =~ "10 * * * *"
+    assert html =~ "Disabled"
+    refute Tasks.get_task!(key).enabled?
+
+    {:ok, _detail_view, detail_html} =
+      live(conn, "/system/tasks/#{URI.encode(key, &URI.char_unreserved?/1)}")
+
+    assert detail_html =~ "Cloud DNS: #{zone_name}"
+    assert detail_html =~ "10 * * * *"
   end
 
   test "queues a task from the overview", %{conn: conn} do
@@ -128,6 +171,22 @@ defmodule YellowDog.Console.TasksLiveTest do
 
     assert html =~ "MAC/OUI sync queued"
     assert [_job | _] = Tasks.recent_jobs(:mac)
+  end
+
+  defp create_cloud_zone(view_name, zone_name, provider) do
+    cloud_mirror = %{
+      enabled: true,
+      connector_name: "cloud-main",
+      provider: provider,
+      zone_id: "",
+      direction: :bidirectional,
+      conflict_strategy: :local_wins
+    }
+
+    :ok =
+      Zone.create_zone(view_name, zone_name, Zone.default_soa(zone_name),
+        cloud_mirror: cloud_mirror
+      )
   end
 
   defp save_env(keys), do: Map.new(keys, &{&1, Application.get_env(:yellow_dog_tasks, &1)})

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks.ex
@@ -34,6 +34,25 @@ defmodule YellowDog.Tasks do
   end
 
   @doc """
+  Updates schedule settings for a known task.
+  """
+  @spec update_task(atom() | String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def update_task(key, attrs) when is_map(attrs) do
+    with {:ok, task} <- DataSync.fetch_task(key),
+         {:ok, _config} <- Config.update_sync_task(task.key, attrs),
+         {:ok, updated_task} <- DataSync.fetch_task(task.key) do
+      {:ok, TaskStatus.put_status(updated_task)}
+    end
+  end
+
+  @doc """
+  Returns the task key for a view-scoped cloud zone sync task.
+  """
+  @spec cloud_zone_task_key(String.t(), String.t()) :: String.t()
+  def cloud_zone_task_key(view_name, zone_name),
+    do: DataSync.cloud_zone_task_key(view_name, zone_name)
+
+  @doc """
   Enqueues a manual sync job for a known task.
   """
   @spec enqueue(atom() | String.t(), keyword()) ::

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks/config.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks/config.ex
@@ -6,6 +6,8 @@ defmodule YellowDog.Tasks.Config do
   alias YellowDog.Tasks.Cron
   alias YellowDog.Config.TomlHelpers
 
+  @cloud_zone_prefix "cloud_zone:"
+
   @type t :: %__MODULE__{
           enabled?: boolean(),
           timezone: Calendar.time_zone(),
@@ -70,6 +72,25 @@ defmodule YellowDog.Tasks.Config do
     Enum.flat_map(@sync_tasks, &cron_entry(&1, config.sync))
   end
 
+  @doc """
+  Updates a task's schedule in the standalone task configuration.
+  """
+  @spec update_sync_task(atom() | String.t(), map()) :: {:ok, t()} | {:error, term()}
+  def update_sync_task(task_key, attrs) when is_map(attrs) do
+    task_key = task_key_to_string(task_key)
+    current_config = load()
+    writable_config = writable_config()
+    current_schedule = Map.get(current_config.sync, task_key, default_dynamic_schedule(task_key))
+
+    with {:ok, schedule} <- schedule_from_attrs(current_schedule, attrs),
+         updated_config <- put_sync_schedule(writable_config, task_key, schedule),
+         :ok <- validate_for_update(updated_config),
+         :ok <- persist_config(updated_config) do
+      Application.put_env(:yellow_dog_tasks, :tasks_config, updated_config)
+      {:ok, load()}
+    end
+  end
+
   defp enabled?(%{"enabled" => enabled}), do: truthy?(enabled)
   defp enabled?(_schedule), do: false
 
@@ -115,7 +136,7 @@ defmodule YellowDog.Tasks.Config do
 
     sync
     |> Map.keys()
-    |> Enum.reject(&MapSet.member?(known_tasks, &1))
+    |> Enum.reject(&(MapSet.member?(known_tasks, &1) or dynamic_task_key?(&1)))
     |> case do
       [] ->
         :ok
@@ -172,7 +193,8 @@ defmodule YellowDog.Tasks.Config do
     raise ArgumentError, "#{path} must be a cron expression string"
   end
 
-  defp validate_max_attempts!(_path, attempts) when is_integer(attempts) and attempts >= 1, do: :ok
+  defp validate_max_attempts!(_path, attempts) when is_integer(attempts) and attempts >= 1,
+    do: :ok
 
   defp validate_max_attempts!(path, attempts) when is_integer(attempts) do
     raise ArgumentError, "#{path} must be greater than or equal to 1, got #{attempts}"
@@ -197,6 +219,132 @@ defmodule YellowDog.Tasks.Config do
   end
 
   defp normalize_keys(config), do: config
+
+  defp writable_config do
+    file_config =
+      :yellow_dog_tasks
+      |> Application.get_env(:config_file_path)
+      |> load_file_config()
+
+    app_config =
+      :yellow_dog_tasks
+      |> Application.get_env(:tasks_config, %{})
+      |> normalize_keys()
+
+    file_config
+    |> deep_merge(app_config)
+    |> Map.put_new("enabled", true)
+    |> Map.put_new("timezone", "Etc/UTC")
+    |> Map.put_new("sync", %{})
+  end
+
+  defp put_sync_schedule(config, task_key, schedule) do
+    sync =
+      config
+      |> Map.get("sync", %{})
+      |> Map.put(task_key, schedule)
+
+    Map.put(config, "sync", sync)
+  end
+
+  defp schedule_from_attrs(current_schedule, attrs) do
+    attrs = normalize_keys(attrs)
+
+    enabled =
+      attrs |> Map.get("enabled", Map.get(current_schedule, "enabled", true)) |> to_boolean()
+
+    cron = attrs |> Map.get("cron", Map.get(current_schedule, "cron")) |> normalize_cron()
+    max_attempts = Map.get(current_schedule, "max_attempts", 3)
+    schedule = %{"enabled" => enabled, "cron" => cron, "max_attempts" => max_attempts}
+
+    try do
+      validate_schedule!("tasks.sync.task", schedule)
+      {:ok, schedule}
+    rescue
+      exception in ArgumentError -> {:error, Exception.message(exception)}
+    end
+  end
+
+  defp normalize_cron(cron) when is_binary(cron), do: String.trim(cron)
+  defp normalize_cron(cron), do: cron
+
+  defp to_boolean(value) when is_list(value), do: value |> List.last() |> to_boolean()
+  defp to_boolean(value) when value in [true, "true", "1", 1, "on"], do: true
+  defp to_boolean(_value), do: false
+
+  defp validate_for_update(config) do
+    try do
+      config
+      |> deep_merge(%{})
+      |> validate_config!()
+
+      :ok
+    rescue
+      exception in ArgumentError -> {:error, Exception.message(exception)}
+    end
+  end
+
+  defp persist_config(config) do
+    case Application.get_env(:yellow_dog_tasks, :config_file_path) do
+      path when is_binary(path) ->
+        TomlHelpers.atomic_write(path, encode_tasks_config(config))
+
+      _path ->
+        :ok
+    end
+  end
+
+  defp encode_tasks_config(config) do
+    sync = Map.get(config, "sync", %{})
+
+    header = [
+      "# Yellow Dog Task Scheduler Configuration",
+      "# Job records and schedule reservations are stored in YellowDog.Store/Concord.",
+      "",
+      "[tasks]",
+      "enabled = #{TomlHelpers.encode_toml_value(Map.get(config, "enabled", true))}",
+      "timezone = #{TomlHelpers.encode_toml_value(Map.get(config, "timezone", "Etc/UTC"))}"
+    ]
+
+    sections =
+      sync
+      |> Enum.sort_by(fn {key, _schedule} -> key end)
+      |> Enum.flat_map(fn {task_key, schedule} ->
+        [
+          "",
+          "[tasks.sync.#{toml_key(task_key)}]",
+          "enabled = #{TomlHelpers.encode_toml_value(Map.get(schedule, "enabled", true))}",
+          "cron = #{TomlHelpers.encode_toml_value(Map.get(schedule, "cron"))}",
+          "max_attempts = #{TomlHelpers.encode_toml_value(Map.get(schedule, "max_attempts", 3))}"
+        ]
+      end)
+
+    Enum.join(header ++ sections, "\n") <> "\n"
+  end
+
+  defp toml_key(key) do
+    if Regex.match?(~r/^[A-Za-z0-9_-]+$/, key) do
+      key
+    else
+      TomlHelpers.encode_toml_string(key)
+    end
+  end
+
+  defp default_dynamic_schedule(task_key) do
+    if dynamic_task_key?(task_key) do
+      %{"enabled" => true, "cron" => "0 * * * *", "max_attempts" => 3}
+    else
+      %{}
+    end
+  end
+
+  defp dynamic_task_key?(key) when is_binary(key),
+    do: String.starts_with?(key, @cloud_zone_prefix)
+
+  defp dynamic_task_key?(_key), do: false
+
+  defp task_key_to_string(key) when is_atom(key), do: Atom.to_string(key)
+  defp task_key_to_string(key) when is_binary(key), do: key
 
   defp truthy?(value), do: value in [true, "true", "1", 1]
 

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks/data_sync.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks/data_sync.ex
@@ -4,10 +4,14 @@ defmodule YellowDog.Tasks.DataSync do
   """
 
   alias YellowDog.Tasks.Config
+  alias YellowDog.Tasks.Workers.SyncCloudZoneWorker
   alias YellowDog.Tasks.Workers.SyncIpDatabaseWorker
   alias YellowDog.Tasks.Workers.SyncMacDatabaseWorker
+  alias YellowDog.Store.Zone
 
   @telemetry_prefix [:yellow_dog, :tasks, :sync]
+  @cloud_zone_prefix "cloud_zone:"
+  @default_cloud_zone_schedule %{"enabled" => true, "cron" => "0 * * * *", "max_attempts" => 3}
 
   @tasks %{
     ip_country: %{
@@ -44,14 +48,18 @@ defmodule YellowDog.Tasks.DataSync do
 
   @spec list_tasks(Config.t()) :: [map()]
   def list_tasks(%Config{} = config) do
-    Enum.map([:ip_country, :ip_city, :mac], &task_with_config!(&1, config))
+    fixed_tasks = Enum.map([:ip_country, :ip_city, :mac], &task_with_config!(&1, config))
+    fixed_tasks ++ cloud_zone_tasks(config)
   end
 
   @spec get_task!(atom() | String.t()) :: map()
   def get_task!(key) do
-    key
-    |> normalize_key!()
-    |> task_with_config!(Config.load())
+    config = Config.load()
+
+    case normalize_fixed_key(key) do
+      {:ok, fixed_key} -> task_with_config!(fixed_key, config)
+      :error -> cloud_zone_task!(to_string(key), config)
+    end
   end
 
   @spec fetch_task(atom() | String.t()) :: {:ok, map()} | {:error, :unknown_task}
@@ -64,9 +72,27 @@ defmodule YellowDog.Tasks.DataSync do
   @spec sync_ip_database(String.t()) :: :ok | {:error, term()}
   def sync_ip_database(type) when type in ["city", "country"] do
     type_atom = ip_database_type(type)
-    downloader = Application.get_env(:yellow_dog_tasks, :ip_database_downloader, &GeoIpDb.Database.download/1)
-    metadata = Application.get_env(:yellow_dog_tasks, :ip_database_metadata, &GeoIpDb.Database.get_metadata/1)
-    file_info = Application.get_env(:yellow_dog_tasks, :ip_database_file_info, &GeoIpDb.Database.file_info/1)
+
+    downloader =
+      Application.get_env(
+        :yellow_dog_tasks,
+        :ip_database_downloader,
+        &GeoIpDb.Database.download/1
+      )
+
+    metadata =
+      Application.get_env(
+        :yellow_dog_tasks,
+        :ip_database_metadata,
+        &GeoIpDb.Database.get_metadata/1
+      )
+
+    file_info =
+      Application.get_env(
+        :yellow_dog_tasks,
+        :ip_database_file_info,
+        &GeoIpDb.Database.file_info/1
+      )
 
     with {:ok, _path} <- downloader.(type_atom),
          {:ok, _metadata} <- metadata.(type_atom),
@@ -91,9 +117,10 @@ defmodule YellowDog.Tasks.DataSync do
         YellowDog.Fingerprint.OuiDatabase.download()
       end)
 
-    info = Application.get_env(:yellow_dog_tasks, :mac_database_info, fn ->
-      YellowDog.Fingerprint.OuiDatabase.info()
-    end)
+    info =
+      Application.get_env(:yellow_dog_tasks, :mac_database_info, fn ->
+        YellowDog.Fingerprint.OuiDatabase.info()
+      end)
 
     with :ok <- ensure_started.(),
          {:ok, _path} <- downloader.(),
@@ -105,12 +132,32 @@ defmodule YellowDog.Tasks.DataSync do
     end
   end
 
-  @spec with_telemetry(atom(), String.t(), String.t() | nil, (-> term())) :: term()
+  @spec sync_cloud_zone(String.t(), String.t()) :: :ok | {:ok, map()} | {:error, term()}
+  def sync_cloud_zone(view_name, zone_name) do
+    sync_fun =
+      Application.get_env(
+        :yellow_dog_tasks,
+        :cloud_zone_sync_fun,
+        &YellowDog.Dns.CloudDnsSync.sync_zone_from_cloud/3
+      )
+
+    sync_fun.(view_name, zone_name, [])
+  end
+
+  @spec cloud_zone_task_key(String.t(), String.t()) :: String.t()
+  def cloud_zone_task_key(view_name, zone_name),
+    do: "#{@cloud_zone_prefix}#{view_name}:#{zone_name}"
+
+  @spec with_telemetry(atom() | String.t(), String.t(), String.t() | nil, (-> term())) :: term()
   def with_telemetry(task, source, job_id, fun) when is_function(fun, 0) do
     started_at = System.monotonic_time()
     metadata = %{task: task, source: source, job_id: job_id}
 
-    :telemetry.execute(@telemetry_prefix ++ [:start], %{system_time: System.system_time()}, metadata)
+    :telemetry.execute(
+      @telemetry_prefix ++ [:start],
+      %{system_time: System.system_time()},
+      metadata
+    )
 
     try do
       case fun.() do
@@ -155,17 +202,78 @@ defmodule YellowDog.Tasks.DataSync do
     |> Map.put(:max_attempts, max_attempts)
   end
 
-  defp normalize_key!(key) when is_atom(key) do
-    if Map.has_key?(@tasks, key), do: key, else: raise(KeyError, key: key, term: @tasks)
+  defp cloud_zone_tasks(config) do
+    case Zone.list_zones() do
+      {:ok, zones} ->
+        zones
+        |> Enum.filter(&cloud_zone?/1)
+        |> Enum.sort_by(&cloud_zone_sort_key/1)
+        |> Enum.map(&cloud_zone_task(&1, config))
+
+      {:error, _reason} ->
+        []
+    end
   end
 
-  defp normalize_key!(key) when is_binary(key) do
-    key
-    |> String.to_existing_atom()
-    |> normalize_key!()
-  rescue
-    ArgumentError -> raise KeyError, key: key, term: @tasks
+  defp cloud_zone_task!(key, config) do
+    config
+    |> cloud_zone_tasks()
+    |> Enum.find(&(&1.key == key))
+    |> case do
+      nil -> raise KeyError, key: key, term: @tasks
+      task -> task
+    end
   end
+
+  defp cloud_zone?(%{zone_type: :auth, cloud_mirror: mirror}) when is_map(mirror) do
+    mirror_enabled?(mirror) and mirror_value(mirror, :connector_name) not in [nil, ""]
+  end
+
+  defp cloud_zone?(_zone), do: false
+
+  defp cloud_zone_task(zone, config) do
+    view_name = Map.fetch!(zone, :view_name)
+    zone_name = Map.fetch!(zone, :origin)
+    key = cloud_zone_task_key(view_name, zone_name)
+    schedule = @default_cloud_zone_schedule |> Map.merge(Map.get(config.sync, key, %{}))
+    max_attempts = Map.get(schedule, "max_attempts", 3)
+
+    %{
+      key: key,
+      label: "Cloud DNS: #{zone_name}",
+      source: provider_label(mirror_value(zone.cloud_mirror, :provider)),
+      worker: SyncCloudZoneWorker,
+      args: %{"view_name" => view_name, "zone_name" => zone_name},
+      enabled?: config.enabled? and enabled?(schedule),
+      cron: Map.get(schedule, "cron"),
+      max_attempts: max_attempts
+    }
+  end
+
+  defp cloud_zone_sort_key(zone), do: {Map.get(zone, :view_name, ""), Map.get(zone, :origin, "")}
+
+  defp mirror_value(mirror, key), do: Map.get(mirror, key) || Map.get(mirror, Atom.to_string(key))
+
+  defp mirror_enabled?(mirror), do: mirror_value(mirror, :enabled) in [true, "true", "1", 1]
+
+  defp provider_label(:cloudflare), do: "Cloudflare DNS"
+  defp provider_label("cloudflare"), do: "Cloudflare DNS"
+  defp provider_label(:route53), do: "AWS Route 53"
+  defp provider_label("route53"), do: "AWS Route 53"
+  defp provider_label(nil), do: "Cloud DNS"
+  defp provider_label(provider), do: to_string(provider)
+
+  defp normalize_fixed_key(key) when is_atom(key) do
+    if Map.has_key?(@tasks, key), do: {:ok, key}, else: :error
+  end
+
+  defp normalize_fixed_key(key) when is_binary(key) do
+    Enum.find_value(@tasks, :error, fn {fixed_key, _task} ->
+      if Atom.to_string(fixed_key) == key, do: {:ok, fixed_key}, else: false
+    end)
+  end
+
+  defp normalize_fixed_key(_key), do: :error
 
   defp enabled?(%{"enabled" => enabled}), do: enabled in [true, "true", "1", 1]
   defp enabled?(_schedule), do: false

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks/job.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks/job.ex
@@ -10,7 +10,7 @@ defmodule YellowDog.Tasks.Job do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          task_key: atom(),
+          task_key: atom() | String.t(),
           worker: module(),
           queue: String.t(),
           args: map(),

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks/store.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks/store.ex
@@ -48,7 +48,12 @@ defmodule YellowDog.Tasks.Store do
 
   @spec mark_executing(Job.t()) :: {:ok, Job.t()} | {:error, term()}
   def mark_executing(%Job{} = job) do
-    updated = %{job | state: "executing", attempt: job.attempt + 1, started_at: DateTime.utc_now()}
+    updated = %{
+      job
+      | state: "executing",
+        attempt: job.attempt + 1,
+        started_at: DateTime.utc_now()
+    }
 
     case put_if_current(job, updated, &match?(%Job{state: "available"}, &1)) do
       :ok -> {:ok, updated}
@@ -122,7 +127,8 @@ defmodule YellowDog.Tasks.Store do
     end
   end
 
-  @spec last_job_result(atom() | String.t(), [String.t()]) :: {:ok, Job.t() | nil} | {:error, term()}
+  @spec last_job_result(atom() | String.t(), [String.t()]) ::
+          {:ok, Job.t() | nil} | {:error, term()}
   def last_job_result(task_key, states) do
     normalized = normalize_key(task_key)
 
@@ -144,7 +150,7 @@ defmodule YellowDog.Tasks.Store do
     ArgumentError -> {:error, :unknown_task}
   end
 
-  @spec reserve_schedule(atom(), String.t()) :: :ok | {:error, term()}
+  @spec reserve_schedule(atom() | String.t(), String.t()) :: :ok | {:error, term()}
   def reserve_schedule(task_key, minute_id) do
     key = Key.task_schedule(task_key)
     reservation = %{task_key: task_key, minute_id: minute_id, reserved_at: DateTime.utc_now()}
@@ -240,7 +246,7 @@ defmodule YellowDog.Tasks.Store do
   end
 
   defp normalize_key(key) when is_atom(key), do: key
-  defp normalize_key(key) when is_binary(key), do: String.to_existing_atom(key)
+  defp normalize_key(key) when is_binary(key), do: key
 
   defp new_job_id do
     16
@@ -283,7 +289,11 @@ defmodule YellowDog.Tasks.Store do
     end)
   end
 
-  defp terminal_at(%Job{state: "completed", completed_at: %DateTime{} = completed_at}), do: completed_at
-  defp terminal_at(%Job{state: "discarded", discarded_at: %DateTime{} = discarded_at}), do: discarded_at
+  defp terminal_at(%Job{state: "completed", completed_at: %DateTime{} = completed_at}),
+    do: completed_at
+
+  defp terminal_at(%Job{state: "discarded", discarded_at: %DateTime{} = discarded_at}),
+    do: discarded_at
+
   defp terminal_at(%Job{inserted_at: inserted_at}), do: inserted_at
 end

--- a/apps/yellow_dog_tasks/lib/yellow_dog/tasks/workers/sync_cloud_zone_worker.ex
+++ b/apps/yellow_dog_tasks/lib/yellow_dog/tasks/workers/sync_cloud_zone_worker.ex
@@ -1,0 +1,23 @@
+defmodule YellowDog.Tasks.Workers.SyncCloudZoneWorker do
+  @moduledoc """
+  Worker for Cloud DNS zone synchronization.
+  """
+
+  alias YellowDog.Tasks.DataSync
+  alias YellowDog.Tasks.Job
+
+  @spec perform(Job.t()) :: :ok | {:ok, map()} | {:error, term()}
+  def perform(%Job{
+        id: job_id,
+        task_key: task_key,
+        args: %{"view_name" => view_name, "zone_name" => zone_name}
+      }) do
+    DataSync.with_telemetry(task_key, "cloud-dns", job_id, fn ->
+      DataSync.sync_cloud_zone(view_name, zone_name)
+    end)
+  end
+
+  def perform(%Job{} = job) do
+    {:error, {:invalid_cloud_zone_args, job.args}}
+  end
+end

--- a/apps/yellow_dog_tasks/mix.exs
+++ b/apps/yellow_dog_tasks/mix.exs
@@ -33,6 +33,7 @@ defmodule YellowDog.Tasks.MixProject do
       {:jason, "~> 1.4"},
       {:yellow_dog_fingerprint, in_umbrella: true},
       {:yellow_dog_config, in_umbrella: true},
+      {:yellow_dog_dns, in_umbrella: true},
       {:yellow_dog_store, in_umbrella: true},
       {:tz, "~> 0.28.2"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},

--- a/apps/yellow_dog_tasks/test/yellow_dog/tasks/config_test.exs
+++ b/apps/yellow_dog_tasks/test/yellow_dog/tasks/config_test.exs
@@ -37,7 +37,11 @@ defmodule YellowDog.Tasks.ConfigTest do
   end
 
   test "loads standalone tasks config file" do
-    path = Path.join(System.tmp_dir!(), "yellowdogdns_tasks_config_#{System.unique_integer([:positive])}.toml")
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "yellowdogdns_tasks_config_#{System.unique_integer([:positive])}.toml"
+      )
 
     File.write!(path, """
     [tasks]
@@ -60,6 +64,63 @@ defmodule YellowDog.Tasks.ConfigTest do
     assert config.sync["ip_city"]["enabled"]
     assert config.sync["ip_city"]["cron"] == "5 1 * * *"
     assert config.sync["ip_city"]["max_attempts"] == 5
+  end
+
+  test "loads quoted cloud zone task config keys" do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "yellowdogdns_tasks_config_#{System.unique_integer([:positive])}.toml"
+      )
+
+    File.write!(path, """
+    [tasks]
+    enabled = true
+    timezone = "Etc/UTC"
+
+    [tasks.sync."cloud_zone:default:example.com"]
+    enabled = false
+    cron = "15 * * * *"
+    max_attempts = 3
+    """)
+
+    on_exit(fn -> File.rm(path) end)
+
+    Application.put_env(:yellow_dog_tasks, :config_file_path, path)
+
+    config = Config.load()
+
+    assert config.sync["cloud_zone:default:example.com"]["enabled"] == false
+    assert config.sync["cloud_zone:default:example.com"]["cron"] == "15 * * * *"
+  end
+
+  test "updates task schedules in standalone task config file" do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "yellowdogdns_tasks_config_#{System.unique_integer([:positive])}.toml"
+      )
+
+    on_exit(fn -> File.rm(path) end)
+
+    Application.put_env(:yellow_dog_tasks, :config_file_path, path)
+
+    assert {:ok, config} =
+             Config.update_sync_task("cloud_zone:default:example.com", %{
+               "enabled" => false,
+               "cron" => "20 * * * *"
+             })
+
+    assert config.sync["cloud_zone:default:example.com"]["enabled"] == false
+    assert config.sync["cloud_zone:default:example.com"]["cron"] == "20 * * * *"
+
+    assert File.read!(path) =~ ~s([tasks.sync."cloud_zone:default:example.com"])
+
+    Application.delete_env(:yellow_dog_tasks, :tasks_config)
+    reloaded = Config.load()
+
+    assert reloaded.sync["cloud_zone:default:example.com"]["enabled"] == false
+    assert reloaded.sync["cloud_zone:default:example.com"]["cron"] == "20 * * * *"
   end
 
   test "returns fixed cron entries for enabled tasks" do
@@ -134,9 +195,11 @@ defmodule YellowDog.Tasks.ConfigTest do
       "sync" => %{"ip_city" => %{"max_attempts" => 0}}
     })
 
-    assert_raise ArgumentError, ~r/tasks.sync.ip_city.max_attempts must be greater than or equal to 1/, fn ->
-      Config.load()
-    end
+    assert_raise ArgumentError,
+                 ~r/tasks.sync.ip_city.max_attempts must be greater than or equal to 1/,
+                 fn ->
+                   Config.load()
+                 end
   end
 
   test "rejects malformed sync config shapes" do
@@ -155,7 +218,19 @@ defmodule YellowDog.Tasks.ConfigTest do
     end
   end
 
-  test "rejects unknown sync task keys" do
+  test "allows cloud zone sync task keys and rejects other unknown sync task keys" do
+    Application.put_env(:yellow_dog_tasks, :tasks_config, %{
+      "sync" => %{
+        "cloud_zone:default:example.com" => %{
+          "enabled" => true,
+          "cron" => "0 * * * *",
+          "max_attempts" => 3
+        }
+      }
+    })
+
+    assert Config.load().sync["cloud_zone:default:example.com"]["cron"] == "0 * * * *"
+
     Application.put_env(:yellow_dog_tasks, :tasks_config, %{
       "sync" => %{"unknown" => %{"enabled" => true, "cron" => "0 0 * * *"}}
     })

--- a/apps/yellow_dog_tasks/test/yellow_dog/tasks/data_sync_test.exs
+++ b/apps/yellow_dog_tasks/test/yellow_dog/tasks/data_sync_test.exs
@@ -11,6 +11,7 @@ defmodule YellowDog.Tasks.DataSyncTest do
   alias YellowDog.Tasks.Workers.SyncIpDatabaseWorker
   alias YellowDog.Tasks.Workers.SyncMacDatabaseWorker
   alias YellowDog.Store.Backend.Ets, as: EtsBackend
+  alias YellowDog.Store.Zone
 
   defmodule ExitWorker do
     @moduledoc false
@@ -83,6 +84,8 @@ defmodule YellowDog.Tasks.DataSyncTest do
         :ip_database_metadata,
         :ip_database_file_info,
         :tasks_config,
+        :config_file_path,
+        :cloud_zone_sync_fun,
         :store_backend,
         :task_supervisor,
         :test_minute_id,
@@ -90,6 +93,8 @@ defmodule YellowDog.Tasks.DataSyncTest do
       ])
 
     Application.put_env(:yellow_dog_tasks, :store_backend, EtsBackend)
+    Application.delete_env(:yellow_dog_tasks, :tasks_config)
+    Application.delete_env(:yellow_dog_tasks, :config_file_path)
     Store.clear_all()
 
     Application.put_env(:yellow_dog_tasks, :ip_database_downloader, fn
@@ -98,7 +103,10 @@ defmodule YellowDog.Tasks.DataSyncTest do
     end)
 
     Application.put_env(:yellow_dog_tasks, :ip_database_metadata, fn _type -> {:ok, %{}} end)
-    Application.put_env(:yellow_dog_tasks, :ip_database_file_info, fn _type -> {:ok, %{size: 1}} end)
+
+    Application.put_env(:yellow_dog_tasks, :ip_database_file_info, fn _type ->
+      {:ok, %{size: 1}}
+    end)
 
     on_exit(fn -> restore_env(previous) end)
 
@@ -110,6 +118,82 @@ defmodule YellowDog.Tasks.DataSyncTest do
 
     assert Enum.map(tasks, & &1.key) == [:ip_country, :ip_city, :mac]
     assert Enum.all?(tasks, &Map.has_key?(&1, :status))
+  end
+
+  test "lists cloud provider zones as hourly sync tasks" do
+    zone_name = "cloud-tasks-#{System.unique_integer([:positive])}.example.com"
+    create_cloud_zone("default", zone_name, :cloudflare)
+
+    tasks = Tasks.list_tasks()
+    key = "cloud_zone:default:#{zone_name}"
+
+    assert [:ip_country, :ip_city, :mac, ^key] = Enum.map(tasks, & &1.key)
+
+    task = Enum.find(tasks, &(&1.key == key))
+
+    assert task.label == "Cloud DNS: #{zone_name}"
+    assert task.source == "Cloudflare DNS"
+    assert task.cron == "0 * * * *"
+    assert task.enabled?
+    assert task.args == %{"view_name" => "default", "zone_name" => zone_name}
+  end
+
+  test "does not list zones without enabled cloud providers" do
+    disabled_zone_name = "cloud-disabled-#{System.unique_integer([:positive])}.example.com"
+    plain_zone_name = "plain-#{System.unique_integer([:positive])}.example.com"
+
+    create_cloud_zone("default", disabled_zone_name, :cloudflare, enabled: false)
+    :ok = Zone.create_zone("default", plain_zone_name, Zone.default_soa(plain_zone_name))
+
+    task_keys = Tasks.list_tasks() |> Enum.map(& &1.key)
+
+    refute "cloud_zone:default:#{disabled_zone_name}" in task_keys
+    refute "cloud_zone:default:#{plain_zone_name}" in task_keys
+  end
+
+  test "updates cloud zone task schedule without creating atoms" do
+    zone_name = "cloud-config-#{System.unique_integer([:positive])}.example.com"
+    create_cloud_zone("default", zone_name, :route53)
+    key = "cloud_zone:default:#{zone_name}"
+
+    assert {:ok, task} =
+             Tasks.update_task(key, %{"enabled" => "false", "cron" => "15 * * * *"})
+
+    assert task.key == key
+    refute task.enabled?
+    assert task.cron == "15 * * * *"
+
+    assert %{"enabled" => false, "cron" => "15 * * * *"} =
+             Application.get_env(:yellow_dog_tasks, :tasks_config)["sync"][key]
+  end
+
+  test "runs due cloud zone schedules" do
+    parent = self()
+    zone_name = "cloud-schedule-#{System.unique_integer([:positive])}.example.com"
+    create_cloud_zone("default", zone_name, :cloudflare)
+    key = "cloud_zone:default:#{zone_name}"
+
+    Application.put_env(:yellow_dog_tasks, :cloud_zone_sync_fun, fn view_name,
+                                                                    sync_zone_name,
+                                                                    opts ->
+      send(parent, {:cloud_sync, view_name, sync_zone_name, opts})
+      {:ok, %{records_synced: 0}}
+    end)
+
+    Application.put_env(:yellow_dog_tasks, :tasks_config, %{
+      "timezone" => "Etc/UTC",
+      "sync" => %{
+        "ip_city" => %{"enabled" => false},
+        "ip_country" => %{"enabled" => false},
+        "mac" => %{"enabled" => false}
+      }
+    })
+
+    assert [%Job{task_key: ^key}] = Runner.run_due_schedules(~U[2026-06-29 02:00:00Z])
+
+    assert_receive {:cloud_sync, "default", ^zone_name, []}, 500
+
+    assert %Job{state: "completed"} = await_recent_job(key, "completed")
   end
 
   test "enqueues and records a known IP database task in Store" do
@@ -130,7 +214,11 @@ defmodule YellowDog.Tasks.DataSyncTest do
       ])
 
     Application.put_env(:yellow_dog_tasks, :mac_database_ensure_started, fn -> :ok end)
-    Application.put_env(:yellow_dog_tasks, :mac_database_downloader, fn -> {:ok, "/tmp/manuf.txt"} end)
+
+    Application.put_env(:yellow_dog_tasks, :mac_database_downloader, fn ->
+      {:ok, "/tmp/manuf.txt"}
+    end)
+
     Application.put_env(:yellow_dog_tasks, :mac_database_info, fn -> %{entry_count: 1} end)
 
     try do
@@ -337,6 +425,22 @@ defmodule YellowDog.Tasks.DataSyncTest do
 
   test "rejects unknown tasks" do
     assert {:error, :unknown_task} = Tasks.enqueue(:unknown)
+  end
+
+  defp create_cloud_zone(view_name, zone_name, provider, opts \\ []) do
+    cloud_mirror = %{
+      enabled: Keyword.get(opts, :enabled, true),
+      connector_name: "cloud-main",
+      provider: provider,
+      zone_id: "",
+      direction: :bidirectional,
+      conflict_strategy: :local_wins
+    }
+
+    :ok =
+      Zone.create_zone(view_name, zone_name, Zone.default_soa(zone_name),
+        cloud_mirror: cloud_mirror
+      )
   end
 
   defp save_env(keys), do: Map.new(keys, &{&1, Application.get_env(:yellow_dog_tasks, &1)})


### PR DESCRIPTION
## Summary
- add dynamic cloud-zone sync tasks for zones with enabled cloud provider metadata, defaulting to hourly sync
- run cloud-zone sync through the Concord-backed task runner and task history instead of the old DNS async job path
- add task schedule/enable editing in the system tasks overview and persist changes to the standalone task config

## Verification
- devenv shell -- mix cmd --app yellow_dog_tasks mix test test/yellow_dog/tasks/config_test.exs test/yellow_dog/tasks/data_sync_test.exs
- devenv shell -- mix cmd --app yellow_dog_console mix test test/yellow_dog/console/live/tasks_live_test.exs test/yellow_dog/console/live/dns_live_test.exs
- devenv shell -- mix format --check-formatted
- devenv shell -- mix cmd --app yellow_dog_tasks mix compile --warnings-as-errors
- devenv shell -- mix cmd --app yellow_dog_console mix compile --warnings-as-errors
- git diff --check